### PR TITLE
Event-driven discovery: per-app AXObservers replace the 1 Hz AX walk

### DIFF
--- a/HyprMac.xcodeproj/project.pbxproj
+++ b/HyprMac.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		F1A48B9952EDF68FE436A6AF /* ConfigStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE062173D513A1A60A3E704D /* ConfigStore.swift */; };
 		F2B3AC04608B7F92C811A44A /* BSPTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF9449D559067A61BBA8394 /* BSPTree.swift */; };
 		F2EFDD2E3E1E512D63BCCE74 /* BundleIDUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E30549B7EABECD4FCDBC0F /* BundleIDUtils.swift */; };
+		F3955661BE1DE991B5D3743E /* AXNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F441CA0A6C21E8CB97A3EB0D /* AXNotificationService.swift */; };
 		F55FE608F36B5FFDC07D1A22 /* TilingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772FFAF897AAC136F605737C /* TilingSettingsView.swift */; };
 /* End PBXBuildFile section */
 
@@ -208,6 +209,7 @@
 		F24369A83C38C9C3757A23FB /* KeyRemapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyRemapper.swift; sourceTree = "<group>"; };
 		F356D39971D5A80B38494D15 /* DwindleLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DwindleLayout.swift; sourceTree = "<group>"; };
 		F397ECC53628484AA2EBD5A2 /* KeyRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyRecorderView.swift; sourceTree = "<group>"; };
+		F441CA0A6C21E8CB97A3EB0D /* AXNotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXNotificationService.swift; sourceTree = "<group>"; };
 		F548FEECDD35DFF1120E2553 /* ConfigMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigMigrationTests.swift; sourceTree = "<group>"; };
 		F95CD8FB8B25B86236401214 /* AppIcon.svg */ = {isa = PBXFileReference; path = AppIcon.svg; sourceTree = "<group>"; };
 		FA85C3347F1D7A782EA9EA39 /* HyprWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyprWindow.swift; sourceTree = "<group>"; };
@@ -313,6 +315,7 @@
 		46404E9F47AD026DEE8E5EB3 /* Discovery */ = {
 			isa = PBXGroup;
 			children = (
+				F441CA0A6C21E8CB97A3EB0D /* AXNotificationService.swift */,
 				8DD3672ACF5C926763242B56 /* WindowDiscoveryService.swift */,
 			);
 			path = Discovery;
@@ -574,6 +577,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F3955661BE1DE991B5D3743E /* AXNotificationService.swift in Sources */,
 				498931AB0DE01FD760A0C1DC /* AccessibilityManager.swift in Sources */,
 				2F7C20004633B3B6A8CCF6D6 /* Action.swift in Sources */,
 				4F7E79CBC44F654BDF24C05B /* ActionDispatcher.swift in Sources */,

--- a/HyprMac/Core/AccessibilityManager.swift
+++ b/HyprMac/Core/AccessibilityManager.swift
@@ -50,6 +50,12 @@ class AccessibilityManager {
     private var axListFailures: [pid_t: Int] = [:]
     private var axFrameDrops: [pid_t: Int] = [:]
 
+    /// Look up a window in the last discovery snapshot by `CGWindowID`.
+    /// Wired by `WindowManager` to `stateCache.cachedWindows[id]`. Lets
+    /// `getFocusedWindow` skip a full AX walk when the focused window was
+    /// already matched on a prior pass. `nil` (unwired) forces the walk.
+    var cachedWindowLookup: ((CGWindowID) -> HyprWindow?)?
+
     private func cgWindowsByPID() -> [pid_t: [CGWindowInfo]] {
         let now = CFAbsoluteTimeGetCurrent()
         if now - cgWindowCacheTime < cgWindowCacheTTL && !cgWindowCacheData.isEmpty {
@@ -278,10 +284,17 @@ class AccessibilityManager {
     /// Resolve the AX-focused window of the frontmost app to a
     /// `HyprWindow`.
     ///
-    /// Routes through `getAllWindows` so the AX→CG matching pass is
-    /// identical — without this, multi-window apps (Finder, Teams) can
-    /// resolve the focused window to a sibling window's `CGWindowID`,
-    /// which silently routes swap/move/close to the wrong window.
+    /// Two paths:
+    /// - **Fast path:** ask AX for the focused element's `CGWindowID`
+    ///   (`_AXUIElementGetWindow`) and look it up in the last discovery
+    ///   snapshot via `cachedWindowLookup`. The snapshot came from a prior
+    ///   `getAllWindows` matching pass, so the result is identical to the
+    ///   full walk — without the ~100+ cross-process AX round-trips.
+    /// - **Fallback:** on a miss (the focused window is newer than the last
+    ///   discovery, or the SPI/lookup is unavailable) run the full
+    ///   `getAllWindows` walk and match by AX element identity. This is the
+    ///   path that avoids the sibling-window misresolution multi-window apps
+    ///   (Finder, Teams) hit when matched by position.
     func getFocusedWindow() -> HyprWindow? {
         guard AXIsProcessTrusted() else { return nil }
         guard let frontApp = NSWorkspace.shared.frontmostApplication else { return nil }
@@ -295,7 +308,13 @@ class AccessibilityManager {
               CFGetTypeID(val) == AXUIElementGetTypeID() else { return nil }
         let focusedAX = val as! AXUIElement
 
-        // look up by AX element identity — same matching pass as getAllWindows
+        // fast path: resolve the CGWindowID directly and hit the snapshot.
+        if let wid = windowID(for: focusedAX), let cached = cachedWindowLookup?(wid) {
+            return cached
+        }
+
+        // fallback: full walk, matched by AX element identity — same matching
+        // pass as getAllWindows so sibling windows don't misresolve.
         return getAllWindows().first { CFEqual($0.element, focusedAX) }
     }
 

--- a/HyprMac/Core/Discovery/AXNotificationService.swift
+++ b/HyprMac/Core/Discovery/AXNotificationService.swift
@@ -69,6 +69,16 @@ final class AXNotificationService {
     // guards attach() against re-entry while the retry is pending.
     private var retrying: Set<pid_t> = []
 
+    // callbacks reach us through an unretained refcon — every run loop
+    // source must be gone before this object is. WindowManager holds the
+    // service for the app's lifetime, so this only backstops a future
+    // teardown path that forgets detachAll().
+    deinit {
+        for entry in entries.values {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(entry.observer), .commonModes)
+        }
+    }
+
     private let selfPID = ProcessInfo.processInfo.processIdentifier
 
     // MARK: - attach / detach

--- a/HyprMac/Core/Discovery/AXNotificationService.swift
+++ b/HyprMac/Core/Discovery/AXNotificationService.swift
@@ -1,0 +1,213 @@
+// Per-app AXObserver fan-out: one observer per regular app, delivering
+// window create / destroy / miniaturize / focus notifications on the main
+// run loop. These are the primary discovery triggers now — the polling
+// scheduler's timer is a slow reconcile safety net (see PollingScheduler).
+
+import Cocoa
+
+/// Owns one `AXObserver` per regular running app and routes their AX
+/// notifications into a single `onEvent` sink.
+///
+/// This is the event-driven front end for discovery. Instead of a 1 Hz
+/// full-desktop AX walk, each app tells us when its windows appear,
+/// vanish, minimize, or take focus; `WindowManager` funnels every event
+/// into the existing coalescing `PollingScheduler.schedule(after:)` so the
+/// real discovery diff (`getAllWindows` → `computeChanges` → `applyChanges`)
+/// runs only when something actually changed. Same architecture as
+/// yabai / AeroSpace.
+///
+/// App-level subscriptions (`kAXWindowCreated`, `kAXFocusedWindowChanged`)
+/// go on the app element and cover the app's whole lifetime. Window-level
+/// subscriptions (`kAXUIElementDestroyed`, `kAXWindowMiniaturized`,
+/// `kAXWindowDeminiaturized`) go on each window element and are attached
+/// lazily via `ensureWindowSubscriptions(for:)` after every discovery pass,
+/// deduped by `CGWindowID`.
+///
+/// Ownership: `AXObserver` and `AXUIElement` are CF types held by ARC in the
+/// per-pid `Entry`, so dropping the entry on `detach` releases them; the run
+/// loop source is removed explicitly first.
+///
+/// Threading: main-thread only. `AXObserverGetRunLoopSource` is added to the
+/// main run loop, so every callback lands on main by construction.
+final class AXNotificationService {
+
+    /// The AX notifications we translate and forward. Each maps to one or
+    /// more `kAX…Notification` strings on the app or window element.
+    enum Kind {
+        case windowCreated
+        case windowDestroyed
+        case windowMiniaturized
+        case windowDeminiaturized
+        case focusedWindowChanged
+    }
+
+    /// Sink for every translated notification. `pid` is the app the event
+    /// belongs to (derived from the firing element). Set by `WindowManager`
+    /// to route into the polling scheduler.
+    var onEvent: ((Kind, pid_t) -> Void)?
+
+    // per-pid observer + its window-level subscription bookkeeping.
+    // the observer and app/window elements are CF types retained by ARC
+    // through these stored properties; releasing the entry releases them.
+    private final class Entry {
+        let observer: AXObserver
+        let appElement: AXUIElement
+        // window ids we've already subscribed at the window level, deduped.
+        var subscribedWindowIDs: Set<CGWindowID> = []
+        // retain the window elements we subscribed to — HyprWindow may be
+        // released between passes, but the observer needs a live element.
+        var windowElements: [CGWindowID: AXUIElement] = [:]
+
+        init(observer: AXObserver, appElement: AXUIElement) {
+            self.observer = observer
+            self.appElement = appElement
+        }
+    }
+
+    private var entries: [pid_t: Entry] = [:]
+    // pids whose first attach failed and are waiting on their single retry.
+    // guards attach() against re-entry while the retry is pending.
+    private var retrying: Set<pid_t> = []
+
+    private let selfPID = ProcessInfo.processInfo.processIdentifier
+
+    // MARK: - attach / detach
+
+    /// Attach an observer to every regular app currently running, skipping
+    /// HyprMac itself. Idempotent per pid.
+    func attachToRunningApps() {
+        mainThreadOnly()
+        for app in NSWorkspace.shared.runningApplications where app.activationPolicy == .regular {
+            attach(pid: app.processIdentifier)
+        }
+    }
+
+    /// Attach an observer to `pid`. No-op if already attached or a retry is
+    /// pending, or for HyprMac's own pid.
+    func attach(pid: pid_t) {
+        mainThreadOnly()
+        guard pid != selfPID else { return }
+        guard entries[pid] == nil, !retrying.contains(pid) else { return }
+        attemptAttach(pid: pid)
+    }
+
+    /// Detach `pid`: remove its run loop source and drop all bookkeeping.
+    /// ARC releases the observer and retained elements.
+    func detach(pid: pid_t) {
+        mainThreadOnly()
+        retrying.remove(pid)
+        guard let entry = entries.removeValue(forKey: pid) else { return }
+        CFRunLoopRemoveSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(entry.observer), .commonModes)
+        hyprLog(.debug, .discovery, "AX observer detached pid=\(pid)")
+    }
+
+    /// Detach every observer. Called from `WindowManager.stop()`.
+    func detachAll() {
+        mainThreadOnly()
+        for pid in Array(entries.keys) { detach(pid: pid) }
+        retrying.removeAll()
+    }
+
+    /// Add window-level subscriptions (destroy / miniaturize / deminiaturize)
+    /// for every window in `snapshot` whose app is attached and whose id we
+    /// haven't subscribed yet. Called after each discovery pass with the
+    /// fresh snapshot.
+    ///
+    /// Deduped by `CGWindowID`. Stale ids (windows since closed) are not
+    /// pruned here — a minimized window legitimately leaves the snapshot but
+    /// must keep its deminiaturize subscription, so snapshot presence can't
+    /// gate removal. `detach` prunes a pid's bookkeeping wholesale on quit.
+    func ensureWindowSubscriptions(for snapshot: [HyprWindow]) {
+        mainThreadOnly()
+        let refcon = Unmanaged.passUnretained(self).toOpaque()
+        for window in snapshot {
+            guard let entry = entries[window.ownerPID] else { continue }
+            let wid = window.windowID
+            guard !entry.subscribedWindowIDs.contains(wid) else { continue }
+
+            let element = window.element
+            AXObserverAddNotification(entry.observer, element, kAXUIElementDestroyedNotification as CFString, refcon)
+            AXObserverAddNotification(entry.observer, element, kAXWindowMiniaturizedNotification as CFString, refcon)
+            AXObserverAddNotification(entry.observer, element, kAXWindowDeminiaturizedNotification as CFString, refcon)
+
+            entry.subscribedWindowIDs.insert(wid)
+            entry.windowElements[wid] = element
+        }
+    }
+
+    // MARK: - internals
+
+    private func attemptAttach(pid: pid_t) {
+        var observer: AXObserver?
+        let createErr = AXObserverCreate(pid, axNotificationCallback, &observer)
+        guard createErr == .success, let observer else {
+            handleAttachFailure(pid: pid, stage: "create", err: createErr)
+            return
+        }
+
+        let appElement = AXUIElementCreateApplication(pid)
+        let refcon = Unmanaged.passUnretained(self).toOpaque()
+        let createdErr = AXObserverAddNotification(observer, appElement, kAXWindowCreatedNotification as CFString, refcon)
+        let focusedErr = AXObserverAddNotification(observer, appElement, kAXFocusedWindowChangedNotification as CFString, refcon)
+
+        // a newly launched app may not be AX-ready — treat "subscribed to
+        // nothing" as a failure and let the retry catch it once.
+        guard createdErr == .success || focusedErr == .success else {
+            handleAttachFailure(pid: pid, stage: "add", err: createdErr == .success ? focusedErr : createdErr)
+            return
+        }
+
+        CFRunLoopAddSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(observer), .commonModes)
+        entries[pid] = Entry(observer: observer, appElement: appElement)
+        retrying.remove(pid)
+        hyprLog(.debug, .discovery, "AX observer attached pid=\(pid)")
+    }
+
+    private func handleAttachFailure(pid: pid_t, stage: String, err: AXError) {
+        if retrying.contains(pid) {
+            // already retried once — give up quietly. the 10s reconcile poll
+            // is the safety net for apps that refuse observers.
+            retrying.remove(pid)
+            hyprLog(.notice, .discovery, "AX observer attach gave up for pid=\(pid) after retry (\(stage) err \(err.rawValue)) — reconcile poll covers it")
+            return
+        }
+        retrying.insert(pid)
+        hyprLog(.debug, .discovery, "AX observer attach failed pid=\(pid) (\(stage) err \(err.rawValue)) — retrying in 2s")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            guard let self else { return }
+            // app may have quit (detach cleared retrying) or attached since.
+            guard self.retrying.contains(pid), self.entries[pid] == nil else { return }
+            self.attemptAttach(pid: pid)
+        }
+    }
+
+    /// Route a raw AX notification (from the C callback) to `onEvent`. The
+    /// firing element gives us the pid regardless of app- vs window-level.
+    fileprivate func handle(notification: String, element: AXUIElement) {
+        let kind: Kind
+        switch notification {
+        case kAXWindowCreatedNotification as String:        kind = .windowCreated
+        case kAXUIElementDestroyedNotification as String:   kind = .windowDestroyed
+        case kAXWindowMiniaturizedNotification as String:   kind = .windowMiniaturized
+        case kAXWindowDeminiaturizedNotification as String: kind = .windowDeminiaturized
+        case kAXFocusedWindowChangedNotification as String: kind = .focusedWindowChanged
+        default: return
+        }
+        var pid: pid_t = 0
+        guard AXUIElementGetPid(element, &pid) == .success else { return }
+        onEvent?(kind, pid)
+    }
+}
+
+// non-capturing C callback — routes through the refcon back to the service.
+// registered on the main run loop, so it fires on main.
+private func axNotificationCallback(
+    _ observer: AXObserver,
+    _ element: AXUIElement,
+    _ notification: CFString,
+    _ refcon: UnsafeMutableRawPointer?
+) {
+    guard let refcon else { return }
+    let service = Unmanaged<AXNotificationService>.fromOpaque(refcon).takeUnretainedValue()
+    service.handle(notification: notification as String, element: element)
+}

--- a/HyprMac/Core/Orchestration/PollingScheduler.swift
+++ b/HyprMac/Core/Orchestration/PollingScheduler.swift
@@ -1,15 +1,20 @@
-// Periodic discovery timer plus the coalescing token that funnels
-// notification-driven polls down to one in-flight scheduled call.
+// Slow reconcile timer plus the coalescing token that funnels
+// event-driven polls down to one in-flight scheduled call.
 
 import Foundation
 
 /// Polling driver for `WindowDiscoveryService`.
 ///
 /// Owns two scheduling primitives:
-/// - A 1 Hz repeating timer that drives steady-state discovery.
-/// - A `pendingPoll` flag that coalesces multiple notification-driven
+/// - A slow (10s) repeating timer that acts as a reconcile safety net —
+///   it catches apps that refuse AX observers, notifications the observer
+///   layer missed, and external moves nothing else reports. It is no
+///   longer the primary discovery trigger.
+/// - A `pendingPoll` flag that coalesces multiple event-driven
 ///   `schedule(after:)` requests in the same debounce window down to a
-///   single fire.
+///   single fire. These come from `AXNotificationService` (window create /
+///   destroy / miniaturize / focus) via `WindowManager` and are the
+///   primary path — the timer only backstops them.
 ///
 /// The discovery work itself is not in this class — the callback supplied
 /// at construction (`onPoll`) does that. The `@objc` notification handlers
@@ -21,9 +26,12 @@ import Foundation
 /// loop and `schedule(after:)` resolves on main via `asyncAfter`.
 final class PollingScheduler {
 
-    /// Periodic discovery interval. Matches v0.4.2 reference behavior.
-    private static let periodicInterval: TimeInterval = 1.0
+    /// Reconcile-timer interval. Slow safety net now that per-app
+    /// AXObserver notifications drive discovery; was 1 Hz before the move
+    /// to event-driven triggers.
+    static let defaultReconcileInterval: TimeInterval = 10.0
 
+    private let periodicInterval: TimeInterval
     private var timer: Timer?
     private var pendingPoll = false
     private let onPoll: () -> Void
@@ -36,22 +44,26 @@ final class PollingScheduler {
     /// Default returns `false`, so existing call sites are unaffected.
     var isSuppressed: () -> Bool = { false }
 
-    init(onPoll: @escaping () -> Void) {
+    /// `periodicInterval` defaults to the 10s reconcile net; tests inject a
+    /// short interval to exercise timer behavior without a 10s wait.
+    init(periodicInterval: TimeInterval = PollingScheduler.defaultReconcileInterval,
+         onPoll: @escaping () -> Void) {
+        self.periodicInterval = periodicInterval
         self.onPoll = onPoll
     }
 
-    /// Start the periodic timer. The caller is expected to have already
+    /// Start the reconcile timer. The caller is expected to have already
     /// run one initial discovery pass synchronously so the first timer
     /// tick cannot race startup tiling. Idempotent.
     func start() {
         guard timer == nil else { return }
-        timer = Timer.scheduledTimer(withTimeInterval: Self.periodicInterval, repeats: true) { [weak self] _ in
+        timer = Timer.scheduledTimer(withTimeInterval: periodicInterval, repeats: true) { [weak self] _ in
             guard let self = self, !self.isSuppressed() else { return }
             self.onPoll()
         }
     }
 
-    /// Stop the periodic timer and clear any in-flight coalesced poll.
+    /// Stop the reconcile timer and clear any in-flight coalesced poll.
     func stop() {
         timer?.invalidate()
         timer = nil
@@ -60,20 +72,29 @@ final class PollingScheduler {
 
     /// Schedule a single coalesced poll `delay` seconds from now.
     ///
-    /// If a poll is already in flight (scheduled but not yet fired), the
-    /// new request is dropped — the in-flight one will fire first and
-    /// capture whatever changed. Suppression is checked twice: at
-    /// scheduling time and again at firing time, so a suppression that
-    /// starts mid-`asyncAfter` still cancels the pending fire.
+    /// If a poll is already pending, the new request is dropped — the
+    /// pending one fires first and captures whatever changed. A fire that
+    /// lands inside a suppression window is deferred (retried at 0.3s),
+    /// not dropped: with event-driven triggers there is no 1 Hz timer
+    /// behind us to catch a lost event, so dropping a suppressed poll
+    /// would leave the change invisible until the 10s reconcile. Every
+    /// suppression is time-bounded (≤4s), so the deferral terminates;
+    /// `stop()` clears `pendingPoll`, which cancels a deferral in flight.
     func schedule(after delay: TimeInterval = 0.2) {
-        guard !isSuppressed() else { return }
         guard !pendingPoll else { return }
         pendingPoll = true
+        armFire(after: delay)
+    }
+
+    private func armFire(after delay: TimeInterval) {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-            guard let self = self else { return }
+            guard let self = self, self.pendingPoll else { return }
+            // suppression re-checked at every fire attempt — defer, don't drop.
+            guard !self.isSuppressed() else {
+                self.armFire(after: 0.3)
+                return
+            }
             self.pendingPoll = false
-            // re-check at fire time — suppression may have started AFTER scheduling.
-            guard !self.isSuppressed() else { return }
             self.onPoll()
         }
     }

--- a/HyprMac/Core/WindowManager.swift
+++ b/HyprMac/Core/WindowManager.swift
@@ -229,12 +229,15 @@ class WindowManager {
         }
         // hold polling off while a cross-monitor drag-swap is in flight (Phase 4 step 5).
         // DragSwapHandler.applySwap registers the "cross-swap-in-flight" key for ~800ms;
-        // both the reconcile timer and event-driven schedule() calls drop until it expires.
         // workspace-transition is set by switchWorkspace and moveToWorkspace for 0.6s
         // so drift detection can't fire on stale-AX-read frames mid-transition.
+        // mouseButtonDown lives here (not as a drop-guard in pollWindowChanges)
+        // so a create/destroy event arriving mid-drag defers and fires on
+        // mouseUp instead of being lost until the 10s reconcile.
         pollingScheduler.isSuppressed = { [weak self] in
             guard let self else { return false }
-            return self.suppressions.isSuppressed("cross-swap-in-flight")
+            return self.mouseButtonDown
+                || self.suppressions.isSuppressed("cross-swap-in-flight")
                 || self.suppressions.isSuppressed("workspace-transition")
         }
 
@@ -2089,6 +2092,9 @@ class WindowManager {
     /// cross-monitor drag-swap completes without pollers stomping on its
     /// in-flight tree mutations.
     private func pollWindowChanges() {
+        // mouse-down is handled by the scheduler's isSuppressed closure so
+        // event polls defer instead of dropping; this guard only backstops
+        // a hypothetical direct call landing mid-drag.
         guard !mouseButtonDown else { return }
 
         let allWindows = accessibility.getAllWindows()

--- a/HyprMac/Core/WindowManager.swift
+++ b/HyprMac/Core/WindowManager.swift
@@ -55,6 +55,10 @@ class WindowManager {
     // and surfaces the rest as a WindowChanges struct that this class applies.
     private var discovery: WindowDiscoveryService!
 
+    // per-app AXObserver fan-out. primary discovery trigger — its events
+    // funnel into pollingScheduler.schedule(after:); the timer is a safety net.
+    private let axNotifications = AXNotificationService()
+
     // floating-window lifecycle: float/tile toggle, cycle-focus, raise-behind, auto-float predicate.
     private(set) var floatingController: FloatingWindowController!
 
@@ -94,7 +98,7 @@ class WindowManager {
 
     // armed when a drag starts on a visible floating window while dim is on
     // (normal mode). drives dimmingOverlay.setDragOverride so the bright carve
-    // hole tracks the floater live instead of trailing on the 1Hz poll.
+    // hole tracks the floater live instead of trailing on the discovery poll.
     private struct DimDragState {
         let id: CGWindowID
         let window: HyprWindow
@@ -225,7 +229,7 @@ class WindowManager {
         }
         // hold polling off while a cross-monitor drag-swap is in flight (Phase 4 step 5).
         // DragSwapHandler.applySwap registers the "cross-swap-in-flight" key for ~800ms;
-        // both the 1Hz timer and notification-driven schedule() calls drop until it expires.
+        // both the reconcile timer and event-driven schedule() calls drop until it expires.
         // workspace-transition is set by switchWorkspace and moveToWorkspace for 0.6s
         // so drift detection can't fire on stale-AX-read frames mid-transition.
         pollingScheduler.isSuppressed = { [weak self] in
@@ -275,6 +279,11 @@ class WindowManager {
             self?.focusBorder.hide()
             self?.dimmingOverlay.hideAll()
         }
+
+        // fast path for getFocusedWindow: resolve the focused element's
+        // CGWindowID against the last discovery snapshot before falling back
+        // to a full AX walk.
+        accessibility.cachedWindowLookup = { [weak self] wid in self?.stateCache.cachedWindows[wid] }
 
         // wire up floating controller — closure handles for WM-side helpers.
         floatingController.animatedRetile = { [weak self] prepare in
@@ -381,6 +390,24 @@ class WindowManager {
         guard !isRunning else { return }
         isRunning = true
 
+        // route AX notifications into the coalescing scheduler. these are the
+        // primary discovery triggers; the scheduler's timer is a safety net.
+        // schedule() already re-checks suppressions at schedule and fire time,
+        // so no extra guards here. create/miniaturize/deminiaturize get a 0.2s
+        // debounce to let AX settle; focus is snappier at 0.15s; destroy uses
+        // the 0.2s default.
+        axNotifications.onEvent = { [weak self] kind, _ in
+            guard let self else { return }
+            switch kind {
+            case .windowDestroyed:
+                self.pollingScheduler.schedule()
+            case .windowCreated, .windowMiniaturized, .windowDeminiaturized:
+                self.pollingScheduler.schedule(after: 0.2)
+            case .focusedWindowChanged:
+                self.pollingScheduler.schedule(after: 0.15)
+            }
+        }
+
         tilingEngine.gapSize = config.gapSize
         tilingEngine.outerPadding = config.outerPadding
         tilingEngine.maxSplitsPerMonitor = config.maxSplitsPerMonitor
@@ -404,9 +431,17 @@ class WindowManager {
             // screen-parameters notification after launch is a no-op.
             self.lastDisplayFingerprint = self.displayFingerprint()
             self.snapshotAndTile()
-            // start polling only after the initial tile so pollWindowChanges can't
-            // race against snapshotAndTile, claim all windows as new, and trigger
-            // an animation that blocks the correct initial distribution
+            // attach AX observers after the initial tile so their events feed
+            // the same coalescing scheduler. this covers the app-level
+            // subscriptions (create / focus); window-level ones (destroy /
+            // miniaturize) get added on the first pollWindowChanges, which the
+            // app-level events or the reconcile timer trigger.
+            self.axNotifications.attachToRunningApps()
+            // start the reconcile timer only after the initial tile so
+            // pollWindowChanges can't race against snapshotAndTile, claim all
+            // windows as new, and trigger an animation that blocks the correct
+            // initial distribution. the timer is now a slow (10s) safety net;
+            // AX notifications above are the primary trigger.
             self.pollingScheduler.start()
         }
 
@@ -603,6 +638,7 @@ class WindowManager {
     func stop() {
         restoreAllWindows()
         isRunning = false
+        axNotifications.detachAll()
         pollingScheduler.stop()
         stopMouseTracking()
         hotkeyManager.stop()
@@ -675,8 +711,8 @@ class WindowManager {
     /// Each monitor delegates to `mouseTracker` (move) or local helpers
     /// (down/drag/up) that maintain the drag-detection scratchpad and the
     /// pre-drag focus-border state. The drag monitor hides the focus border
-    /// for floating windows because the border only repositions on the 1Hz
-    /// poll and would otherwise lag the live drag at 60Hz; mouseUp restores
+    /// for floating windows because the border only repositions on the
+    /// discovery poll and would otherwise lag the live drag at 60Hz; mouseUp restores
     /// it after a short settle delay.
     private func startMouseTracking() {
         mouseMoveMonitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { [weak self] _ in
@@ -717,7 +753,7 @@ class WindowManager {
             }
         }
         // when the user drags a floating window, its frame changes 60Hz but our
-        // border only repositions on poll (1Hz) — so it lags behind ugly. hide
+        // border only repositions on the discovery poll — so it lags behind ugly. hide
         // the border for the duration of the drag and restore it on mouseUp.
         mouseDragMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDragged) { [weak self] _ in
             guard let self = self else { return }
@@ -1003,8 +1039,8 @@ class WindowManager {
     /// Read live AX frames for every visible tile before dim or border
     /// computations.
     ///
-    /// `stateCache.tiledPositions` only refreshes on poll/retile (1Hz timer
-    /// plus activation/launch notifications). Between those events a window
+    /// `stateCache.tiledPositions` only refreshes on poll/retile (the
+    /// reconcile timer plus AX / activation / launch notifications). Between those events a window
     /// can resize or move — app self-resize, AX min-size kick-in, manual
     /// drag, pass-2 layout responding to a constraint — and the cache goes
     /// stale. Without the live re-read, `refreshDimming` and the border
@@ -2056,6 +2092,9 @@ class WindowManager {
         guard !mouseButtonDown else { return }
 
         let allWindows = accessibility.getAllWindows()
+        // add window-level AX subscriptions (destroy / miniaturize) for any
+        // new windows in this snapshot — deduped by CGWindowID inside.
+        axNotifications.ensureWindowSubscriptions(for: allWindows)
         tilingEngine.primeMinimumSizes(allWindows)
         let runningPIDs = Set(NSWorkspace.shared.runningApplications.map { $0.processIdentifier })
 
@@ -2237,6 +2276,11 @@ class WindowManager {
     /// React to a new app launch. Half-second delay gives the app time to
     /// open its first window before discovery runs.
     @objc private func appDidLaunch(_ notification: Notification) {
+        if let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication {
+            // wire up event-driven discovery for the new app. attach is
+            // idempotent and retries once if the app isn't AX-ready yet.
+            axNotifications.attach(pid: app.processIdentifier)
+        }
         pollingScheduler.schedule(after: 0.5)
     }
 
@@ -2246,6 +2290,7 @@ class WindowManager {
     /// path can only see windows still in `knownWindowIDs`.
     @objc private func appDidTerminate(_ notification: Notification) {
         if let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication {
+            axNotifications.detach(pid: app.processIdentifier)
             forgetApp(app.processIdentifier)
         }
         pollingScheduler.schedule()
@@ -2267,6 +2312,18 @@ class WindowManager {
     /// order would prune the home-screen mapping first and orphan the
     /// migration.
     @objc private func screenParametersChanged() {
+        // macOS fires this for events that don't alter the layout — app
+        // quits, color profile changes, 1px visibleFrame jitter (the
+        // fingerprint keys on frame, not visibleFrame). those used to pay
+        // the full 3s discovery suppression + scratchpad hide before the
+        // debounce concluded "unchanged"; with event-driven discovery a
+        // spurious 3s suppression starves window ingestion, so bail first.
+        // mid-debounce fires (displayTransitionPending) must keep flowing
+        // through the generation machinery below.
+        if !displayTransitionPending && displayFingerprint() == lastDisplayFingerprint {
+            hyprLog(.debug, .lifecycle, "screenParametersChanged: fingerprint unchanged — ignoring spurious fire")
+            return
+        }
         let names = displayManager.screens.map { $0.localizedName }.joined(separator: ", ")
         hyprLog(.notice, .lifecycle, "screenParametersChanged fired (current screens: [\(names)])")
         // the scratchpad can't survive a topology change — reconcile would

--- a/HyprMacTests/PollingSchedulerTests.swift
+++ b/HyprMacTests/PollingSchedulerTests.swift
@@ -72,45 +72,51 @@ final class PollingSchedulerTests: XCTestCase {
         XCTAssertLessThanOrEqual(elapsed, 0.30)
     }
 
-    // MARK: - start / stop
+    // MARK: - reconcile timer
+
+    // the production reconcile interval is a slow 10s safety net now that
+    // AXObserver notifications drive discovery. these timer tests inject a
+    // short interval so they exercise the timer without a 10s wait; the
+    // production value is pinned separately in testDefaultReconcileIntervalIsSlow.
+
+    func testDefaultReconcileIntervalIsSlow() {
+        // contract: the timer is a slow reconcile net, not a 1 Hz poller.
+        XCTAssertEqual(PollingScheduler.defaultReconcileInterval, 10.0)
+    }
 
     func testStartFiresPeriodicTimer() {
         var fireCount = 0
-        let scheduler = PollingScheduler { fireCount += 1 }
-        let exp = expectation(description: "first periodic tick")
+        let scheduler = PollingScheduler(periodicInterval: 0.2) { fireCount += 1 }
+        let exp = expectation(description: "first reconcile tick")
 
         scheduler.start()
-        // periodic interval is 1.0s — wait long enough for one tick but cap
-        // the test runtime. periodicInterval is private; this asserts behavior,
-        // not the exact value.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { exp.fulfill() }
-        wait(for: [exp], timeout: 3.0)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
         scheduler.stop()
         XCTAssertGreaterThanOrEqual(fireCount, 1)
     }
 
     func testStopHaltsPeriodicTicks() {
         var fireCount = 0
-        let scheduler = PollingScheduler { fireCount += 1 }
+        let scheduler = PollingScheduler(periodicInterval: 0.2) { fireCount += 1 }
         scheduler.start()
         scheduler.stop()
         let countAfterStop = fireCount
 
         let exp = expectation(description: "no further ticks after stop")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { exp.fulfill() }
-        wait(for: [exp], timeout: 3.0)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
         XCTAssertEqual(fireCount, countAfterStop)
     }
 
-    func testStopClearsInFlightToken() {
+    func testStopCancelsInFlightPollAndClearsToken() {
         var fireCount = 0
         let scheduler = PollingScheduler { fireCount += 1 }
         let exp = expectation(description: "post-stop schedule fires")
 
-        // schedule a poll, immediately stop — the in-flight asyncAfter will still
-        // fire (we don't cancel it), but the token must clear on stop so a fresh
-        // schedule after start() goes through. the closure increments fireCount
-        // either way; we're asserting the token state, not closure invocation count.
+        // schedule a poll, immediately stop — clearing pendingPoll cancels
+        // the in-flight fire (the closure bails on a cleared token), and the
+        // token must clear so a fresh schedule after start() goes through.
         scheduler.schedule(after: 0.05)
         scheduler.stop()
 
@@ -122,75 +128,94 @@ final class PollingSchedulerTests: XCTestCase {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { exp.fulfill() }
         wait(for: [exp], timeout: 1.0)
         scheduler.stop()
-        // 1 from the pre-stop in-flight + 1 from the post-start schedule
-        XCTAssertGreaterThanOrEqual(fireCount, 2)
+        // only the post-start schedule fires; the pre-stop one was canceled
+        XCTAssertEqual(fireCount, 1)
     }
 
     // MARK: - suppression (Phase 4 step 5)
 
-    func testSuppressedScheduleIsDropped() {
-        var fireCount = 0
-        let scheduler = PollingScheduler { fireCount += 1 }
-        scheduler.isSuppressed = { true }
-
-        let exp = expectation(description: "no fire")
-        scheduler.schedule(after: 0.05)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.20) { exp.fulfill() }
-        wait(for: [exp], timeout: 1.0)
-        XCTAssertEqual(fireCount, 0, "suppressed schedule must not fire")
-    }
-
-    func testSuppressionStartedAfterScheduleStillBlocksFire() {
-        var fireCount = 0
-        var suppressed = false
-        let scheduler = PollingScheduler { fireCount += 1 }
-        scheduler.isSuppressed = { suppressed }
-
-        let exp = expectation(description: "no fire")
-        // schedule with no suppression, then suppress before the asyncAfter resolves.
-        // the fire-time re-check must drop the call — this is the cross-swap path:
-        // a 1Hz poll could land just as DragSwapHandler enters its critical section.
-        scheduler.schedule(after: 0.10)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) { suppressed = true }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { exp.fulfill() }
-        wait(for: [exp], timeout: 1.0)
-        XCTAssertEqual(fireCount, 0, "suppression starting mid-flight must drop the fire")
-    }
-
-    func testTimerTickHonoursSuppression() {
+    func testSuppressedScheduleDefersUntilSuppressionLifts() {
         var fireCount = 0
         var suppressed = true
         let scheduler = PollingScheduler { fireCount += 1 }
         scheduler.isSuppressed = { suppressed }
 
+        // while suppressed the poll must not fire — but it must not be lost
+        // either. with event-driven triggers there's no 1 Hz timer to catch a
+        // dropped event (a windowCreated during a workspace transition would
+        // go unmanaged until the 10s reconcile), so the fire defers and lands
+        // once the suppression lifts.
+        let stillSuppressed = expectation(description: "no fire while suppressed")
+        scheduler.schedule(after: 0.05)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.20) {
+            XCTAssertEqual(fireCount, 0, "suppressed poll must not fire")
+            suppressed = false
+            stillSuppressed.fulfill()
+        }
+        let fired = expectation(description: "deferred poll fired after lift")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.80) { fired.fulfill() }
+        wait(for: [stillSuppressed, fired], timeout: 2.0)
+        XCTAssertEqual(fireCount, 1, "deferred poll must fire exactly once after suppression lifts")
+    }
+
+    func testSuppressionStartedAfterScheduleDefersFire() {
+        var fireCount = 0
+        var suppressed = false
+        let scheduler = PollingScheduler { fireCount += 1 }
+        scheduler.isSuppressed = { suppressed }
+
+        // schedule with no suppression, then suppress before the asyncAfter
+        // resolves — the cross-swap path: a poll landing mid-critical-section
+        // must hold off, then fire once the suppression clears.
+        scheduler.schedule(after: 0.10)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) { suppressed = true }
+        let stillSuppressed = expectation(description: "no fire while suppressed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.30) {
+            XCTAssertEqual(fireCount, 0, "suppression starting mid-flight must defer the fire")
+            suppressed = false
+            stillSuppressed.fulfill()
+        }
+        let fired = expectation(description: "deferred poll fired after lift")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.90) { fired.fulfill() }
+        wait(for: [stillSuppressed, fired], timeout: 2.0)
+        XCTAssertEqual(fireCount, 1, "deferred poll must fire exactly once after suppression lifts")
+    }
+
+    func testTimerTickHonoursSuppression() {
+        var fireCount = 0
+        var suppressed = true
+        let scheduler = PollingScheduler(periodicInterval: 0.2) { fireCount += 1 }
+        scheduler.isSuppressed = { suppressed }
+
         scheduler.start()
         // wait long enough for ~one tick. while suppressed, ticks must drop.
         let exp1 = expectation(description: "first window")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { exp1.fulfill() }
-        wait(for: [exp1], timeout: 3.0)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { exp1.fulfill() }
+        wait(for: [exp1], timeout: 2.0)
         XCTAssertEqual(fireCount, 0, "suppressed timer must not fire onPoll")
 
         // lift suppression and confirm subsequent ticks fire.
         suppressed = false
         let exp2 = expectation(description: "second window")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { exp2.fulfill() }
-        wait(for: [exp2], timeout: 3.0)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { exp2.fulfill() }
+        wait(for: [exp2], timeout: 2.0)
         scheduler.stop()
         XCTAssertGreaterThanOrEqual(fireCount, 1, "post-suppression timer must resume firing")
     }
 
     func testDoubleStartIsIdempotent() {
         var fireCount = 0
-        let scheduler = PollingScheduler { fireCount += 1 }
+        let scheduler = PollingScheduler(periodicInterval: 0.3) { fireCount += 1 }
         let exp = expectation(description: "tick")
 
         scheduler.start()
         scheduler.start() // second start must not install a second timer
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { exp.fulfill() }
-        wait(for: [exp], timeout: 3.0)
+        // one timer fires once in a 0.5s window (next tick lands at ~0.6s);
+        // a second timer would double the count to 2.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
         scheduler.stop()
-        // exactly one timer means roughly one tick in 1.5s, not two
         XCTAssertEqual(fireCount, 1)
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,12 +72,25 @@ These types decompose what would otherwise be a monolithic
 - **`SuppressionRegistry`** is a tiny date-gated key-value store for
   short-lived "don't react to X for Y seconds" flags
   (`activation-switch`, `mouse-focus`, `cross-swap-in-flight`).
-- **`PollingScheduler`** owns the 1 Hz periodic discovery timer plus a
-  coalescing token that funnels notification-driven `schedule(after:)`
-  requests down to a single in-flight call. Honors
+- **`PollingScheduler`** owns a slow (10s) reconcile timer plus a
+  coalescing token that funnels event-driven `schedule(after:)` requests
+  down to a single in-flight call. The timer is a safety net — it catches
+  apps that refuse AX observers, notifications the observer layer missed,
+  and external moves nothing else reports; `AXNotificationService` events
+  are the primary trigger. Honors
   `SuppressionRegistry["cross-swap-in-flight"]` so cross-monitor
   drag-swap can hold polling off for the duration of its two
   back-to-back retiles.
+- **`AXNotificationService`** owns one `AXObserver` per regular app and
+  translates their AX notifications (window created / destroyed /
+  miniaturized / deminiaturized, focused-window changed) into
+  `schedule(after:)` calls on `PollingScheduler`. This is the
+  event-driven front end that replaced the 1 Hz full-desktop AX walk:
+  apps report changes instead of being polled, so the discovery diff runs
+  only when something changed. App-level subscriptions attach on
+  `attachToRunningApps` / `attach(pid:)`; window-level ones attach lazily
+  via `ensureWindowSubscriptions(for:)` after each discovery pass. Same
+  architecture as yabai / AeroSpace.
 - **`WindowDiscoveryService`** runs the diff between the previous and
   current AX snapshot. Owns the lifecycle/classification cache
   mutations on the discovery path; surfaces the rest in a
@@ -95,7 +108,7 @@ These types decompose what would otherwise be a monolithic
 Hotkey trigger:
 
 ```
-HotkeyManager.eventTap (CGEventTap, main run loop)
+HotkeyManager.eventTap (CGEventTap, dedicated thread → dispatched to main)
   → WindowManager.handleAction
   → ActionDispatcher.dispatch
     ├ FocusStateController       (focus id + visual border)
@@ -114,11 +127,18 @@ FocusBorder, FocusBrackets, DimmingOverlay (visual layer)
 Polling / discovery (parallel):
 
 ```
-PollingScheduler.timer or NSWorkspace notifications
+AXNotificationService (per-app AXObserver)     ┐
+NSWorkspace notifications (launch/hide/…)       ├→ PollingScheduler.schedule(after:)
+PollingScheduler.timer (10s reconcile net)     ┘        (coalesced)
   → WindowManager.pollWindowChanges
-  → WindowDiscoveryService.computeChanges
-  → ActionDispatcher.applyChanges
+    → AccessibilityManager.getAllWindows
+    → AXNotificationService.ensureWindowSubscriptions   (window-level subs)
+    → WindowDiscoveryService.computeChanges
+    → ActionDispatcher.applyChanges
 ```
+
+Per-app AXObserver notifications are the primary discovery trigger; the
+10s timer only backstops missed events and observer-refusing apps.
 
 ## Ownership rules
 

--- a/plans/performance-investigation.md
+++ b/plans/performance-investigation.md
@@ -133,11 +133,24 @@ The slider structurally cannot touch the problem.
 
 ### Phase 1 — structural
 
-6. **Event-driven discovery**: per-app `AXObserver` attached on NSWorkspace
-   launch notifications (created/moved/resized/destroyed/miniaturized/
-   focusChanged) + keep a slow reconcile poll (~10 s) as safety net. Skip AX
-   reads for windows parked on invisible workspaces. This removes the 1 Hz
-   full-desktop walk — the "other apps stall" half of the problem.
+6. **DONE (2026-07-08, branch perf/phase1-event-driven-discovery) —
+   event-driven discovery**: `AXNotificationService` owns one `AXObserver`
+   per regular app (created/focusChanged app-level; destroyed/miniaturized/
+   deminiaturized window-level, attached lazily post-discovery). Events
+   funnel into the existing coalescing `PollingScheduler.schedule(after:)`;
+   the timer is now a 10 s reconcile safety net. `getFocusedWindow()` gained
+   a windowID→cache fast path (full walk only on miss). Two fixes shaken out
+   by live testing: (a) suppressed polls now *defer* (0.3 s retry) instead of
+   dropping — with no 1 Hz timer behind them, a dropped event meant a window
+   went unmanaged until the reconcile; (b) `screenParametersChanged` bails
+   before suppressing when the display fingerprint is unchanged — macOS fires
+   it spuriously (1 px visibleFrame jitter), and each fire used to cost a 3 s
+   discovery suppression. Deliberately NOT subscribed: moved/resized (poll
+   storms during drags; the drag system + reconcile cover those).
+   Deferred within this item: skipping AX attribute reads for parked
+   hidden-workspace windows (needs a hidden-window cache that doesn't exist;
+   staleness risk in gone-detection — revisit only if measurements say the
+   per-event walks still hurt).
 7. **AX off the main thread**: serial AX work queue or AeroSpace-style
    thread-per-app with cancellable jobs. Most invasive (the codebase is
    main-thread-only by design) — do it after 1–6, only if needed; measure first.

--- a/plans/performance-investigation.md
+++ b/plans/performance-investigation.md
@@ -159,6 +159,40 @@ The slider structurally cannot touch the problem.
    full-screen transparent panels; JankyBorders-style SLS drawing for
    FocusBorder if WindowServer load persists.
 
+### Measurement-gated (re-scoped 2026-07-08 after Phases 0–1 landed)
+
+The remaining items — **readback de-sleep**, **overlay diet (8)**,
+**AX-off-main (7)**, **parked-window read skip** — are all gated on a soak
+period with Phases 0–1 running, not scheduled work.
+
+Re-scoping rationale for the de-sleep specifically: the readback loop's
+while-condition exits immediately when every frame lands within tolerance,
+so a compliant retile pays ONE 30 ms sleep, not 360 ms. The 360 ms tail
+fires only on genuine min-size conflicts / cross-screen races, and since
+Phase 0 it cannot touch system input (tap is off main) — it only delays
+HyprMac-internal reactions during a retile whose windows are visibly moving
+anyway. Converting the two-pass settle to an async state machine would
+touch the most subtle machinery in the codebase (MinSizeMemory ratcheting,
+DragSwapHandler's 0.8 s suppression budget, every caller that sequences
+retile → focus → border) for that narrow tail. Do it only if soak
+measurements show retile-time jank that matters.
+
+### Soak measurement checklist (run after ~a day of normal use)
+
+```bash
+# 1. tap timeouts — was 15/day pre-fix; target 0
+/usr/bin/log show --last 1d --predicate 'subsystem == "com.zachgray.HyprMac"' --info \
+  | grep -c "event tap disabled (timeout)"
+# 2. WindowServer CPU-limit diagnostics — should stop appearing
+ls -lat /Library/Logs/DiagnosticReports/ | grep -i windowserver | head -5
+# 3. AX read failures + focus churn volume (context, not pass/fail)
+/usr/bin/log show --last 1d --predicate 'subsystem == "com.zachgray.HyprMac"' --info \
+  | grep -cE "AX window-list read FAILED|activate dropped"
+```
+
+Plus the subjective checks: typing latency while a retile / workspace
+switch is in flight, and whether other apps still hitch during idle.
+
 ### Verification metric
 
 Tap timeouts are directly countable — the before/after metric:


### PR DESCRIPTION
## Why

Phase 1 of plans/performance-investigation.md. After #6 fixed the input-freeze half (event tap off the main run loop), this fixes the other half: the 1 Hz full-desktop AX walk was injecting ~100-250 synchronous cross-process round-trips per second into every running app's main thread — permanent micro-jank across the whole system.

## What

- **`AXNotificationService`** (new): one `AXObserver` per regular app. App-level subscriptions (windowCreated, focusedWindowChanged) attach on start/app-launch with a single 2s retry for AX-not-ready apps; window-level (destroyed, miniaturized, deminiaturized) attach lazily after each discovery pass, deduped by window ID. Events funnel into the existing coalescing `PollingScheduler.schedule(after:)` — **the discovery diff pipeline is unchanged, only its triggers**.
- **Reconcile timer 1s → 10s** (injectable for tests): catches observer-refusing apps, missed notifications, and external moves.
- **Suppressed polls defer instead of dropping** (0.3s retry until the time-bounded suppression lifts). Live testing caught this: without a 1 Hz timer behind it, a windowCreated dropped by a suppression left the window unmanaged until the reconcile.
- **`screenParametersChanged` bails on unchanged fingerprint** before paying the 3s discovery suppression + scratchpad hide. Also caught live: macOS fires it spuriously (1px visibleFrame jitter — 8 times in a 20s capture on this machine).
- **`getFocusedWindow()` fast path**: focused element → CGWindowID → snapshot lookup; the sibling-window-safe full walk remains as the miss fallback.
- Deliberately NOT subscribed: moved/resized (poll storms during floater drags; drag system + reconcile cover those).

## Verification

- 216/216 tests (suppression tests rewritten to encode the deferral contract; new test pins the 10s reconcile interval).
- Live on this machine: TextEdit window **tiled ~0.5s after launch**, layout gap **closed ~0.16s after quit** (both faster than the old 1 Hz poll), observers attach/detach on app lifecycle, spurious screen-param fires ignored, steady-state log silence between events.