### PR TITLE
feat: keyboard window resizing via resizeDirection action

### DIFF
--- a/HyprMac.xcodeproj/project.pbxproj
+++ b/HyprMac.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		0086DBE1974C316B4B7AE242 /* ColorPickerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F2F88E3A815333F6542EEA /* ColorPickerRow.swift */; };
 		00B50053F139D098B090709F /* WindowDiscoveryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857FCC6A226AFEECD7A199FC /* WindowDiscoveryServiceTests.swift */; };
 		049A911F001515424E52E5B9 /* BSPNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AC17310FABAC0CFEA327E7 /* BSPNodeTests.swift */; };
-		5AD7A1FCD49C5A8F5B749EE8 /* ResizeDirectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DFC0175B34415C25073FEA /* ResizeDirectionTests.swift */; };
 		0A95C40458C159F8851E03E4 /* BSPTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A85F3FF392095FDDB36DAB7 /* BSPTestSupport.swift */; };
 		0B9D198B68374BB6E0D0FA1F /* DragManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E56F3B2C9834C78368323D /* DragManager.swift */; };
 		0D4C6B4D33142A677A590C35 /* DisplayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593D96A7340421A4588DE5D5 /* DisplayManager.swift */; };
@@ -69,6 +68,7 @@
 		98D72FEBD5773242B4F199B7 /* PollingSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18F440861EC1F33CEB326CB4 /* PollingSchedulerTests.swift */; };
 		9D75A3D3BAA41C0012711D6D /* UserConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A029C0AE0E8E5DEE2416684 /* UserConfig.swift */; };
 		A34F6208901205B1100F08AE /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB697B2619BEB7E2434E157E /* WelcomeView.swift */; };
+		A78F1FAAB49BEEEAE2A1844D /* ResizeDirectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E97E23BFC7B85A7E6BF506 /* ResizeDirectionTests.swift */; };
 		AC01521BE9F2030CF901A2C9 /* DragSwapHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB2A500B78D0C9A7FAE6173 /* DragSwapHandler.swift */; };
 		B44C416E3958C82361083048 /* KeybindOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7BD70717FD497B0899FBCE5 /* KeybindOverlayController.swift */; };
 		B6C40B2479058C399AD8153B /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5627CA2ADE2AA85B3372EB81 /* SettingsView.swift */; };
@@ -121,7 +121,6 @@
 		084CC77D9BC9594A5E7DE366 /* FocusStateControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusStateControllerTests.swift; sourceTree = "<group>"; };
 		0B9CF795BFCF2AE866D59470 /* KeybindsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindsSettingsView.swift; sourceTree = "<group>"; };
 		12DCA371573CAAC4B23A96AA /* PrepareLayoutMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepareLayoutMutationTests.swift; sourceTree = "<group>"; };
-		14DFC0175B34415C25073FEA /* ResizeDirectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizeDirectionTests.swift; sourceTree = "<group>"; };
 		16AC17310FABAC0CFEA327E7 /* BSPNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BSPNodeTests.swift; sourceTree = "<group>"; };
 		17ABB08FA82CF475A82AB3C5 /* KeybindEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindEditorViewModel.swift; sourceTree = "<group>"; };
 		18F440861EC1F33CEB326CB4 /* PollingSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingSchedulerTests.swift; sourceTree = "<group>"; };
@@ -153,6 +152,7 @@
 		5C0116BE6F796AC619B0BD6B /* CoordinateSpace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateSpace.swift; sourceTree = "<group>"; };
 		61E1DEE768A398E963AAB1CA /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
 		63E30549B7EABECD4FCDBC0F /* BundleIDUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleIDUtils.swift; sourceTree = "<group>"; };
+		64E97E23BFC7B85A7E6BF506 /* ResizeDirectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizeDirectionTests.swift; sourceTree = "<group>"; };
 		65F2F88E3A815333F6542EEA /* ColorPickerRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerRow.swift; sourceTree = "<group>"; };
 		6B23E3313247FD77173D35DD /* DefaultKeybindsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultKeybindsTests.swift; sourceTree = "<group>"; };
 		6E4E656D3CA021B130775CC3 /* Keybind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keybind.swift; sourceTree = "<group>"; };
@@ -425,7 +425,7 @@
 				298318CA91C080E2C130A4DE /* LayoutEngineTests.swift */,
 				18F440861EC1F33CEB326CB4 /* PollingSchedulerTests.swift */,
 				12DCA371573CAAC4B23A96AA /* PrepareLayoutMutationTests.swift */,
-				14DFC0175B34415C25073FEA /* ResizeDirectionTests.swift */,
+				64E97E23BFC7B85A7E6BF506 /* ResizeDirectionTests.swift */,
 				306A7B2B7B3F09F08F953F35 /* SuppressionRegistryTests.swift */,
 				3246386B0F502F2D858B3033 /* TileScratchpadTests.swift */,
 				DC08AAC03ABC15E772214598 /* ToggleSplitFallthroughRegressionTests.swift */,
@@ -677,7 +677,7 @@
 				15AB8B9331E6A03CDD991F3C /* LayoutEngineTests.swift in Sources */,
 				98D72FEBD5773242B4F199B7 /* PollingSchedulerTests.swift in Sources */,
 				CAF7E4C0660A5075D1D9DD62 /* PrepareLayoutMutationTests.swift in Sources */,
-				5AD7A1FCD49C5A8F5B749EE8 /* ResizeDirectionTests.swift in Sources */,
+				A78F1FAAB49BEEEAE2A1844D /* ResizeDirectionTests.swift in Sources */,
 				EDC0EDCDC01F4A5310E4A07E /* SuppressionRegistryTests.swift in Sources */,
 				8456B287CD1B9AC9E86336E5 /* TileScratchpadTests.swift in Sources */,
 				860959AD6A92DB57753D655E /* ToggleSplitFallthroughRegressionTests.swift in Sources */,

--- a/HyprMac.xcodeproj/project.pbxproj
+++ b/HyprMac.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0086DBE1974C316B4B7AE242 /* ColorPickerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F2F88E3A815333F6542EEA /* ColorPickerRow.swift */; };
 		00B50053F139D098B090709F /* WindowDiscoveryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857FCC6A226AFEECD7A199FC /* WindowDiscoveryServiceTests.swift */; };
 		049A911F001515424E52E5B9 /* BSPNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AC17310FABAC0CFEA327E7 /* BSPNodeTests.swift */; };
+		5AD7A1FCD49C5A8F5B749EE8 /* ResizeDirectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DFC0175B34415C25073FEA /* ResizeDirectionTests.swift */; };
 		0A95C40458C159F8851E03E4 /* BSPTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A85F3FF392095FDDB36DAB7 /* BSPTestSupport.swift */; };
 		0B9D198B68374BB6E0D0FA1F /* DragManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E56F3B2C9834C78368323D /* DragManager.swift */; };
 		0D4C6B4D33142A677A590C35 /* DisplayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593D96A7340421A4588DE5D5 /* DisplayManager.swift */; };
@@ -120,6 +121,7 @@
 		084CC77D9BC9594A5E7DE366 /* FocusStateControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusStateControllerTests.swift; sourceTree = "<group>"; };
 		0B9CF795BFCF2AE866D59470 /* KeybindsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindsSettingsView.swift; sourceTree = "<group>"; };
 		12DCA371573CAAC4B23A96AA /* PrepareLayoutMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepareLayoutMutationTests.swift; sourceTree = "<group>"; };
+		14DFC0175B34415C25073FEA /* ResizeDirectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizeDirectionTests.swift; sourceTree = "<group>"; };
 		16AC17310FABAC0CFEA327E7 /* BSPNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BSPNodeTests.swift; sourceTree = "<group>"; };
 		17ABB08FA82CF475A82AB3C5 /* KeybindEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindEditorViewModel.swift; sourceTree = "<group>"; };
 		18F440861EC1F33CEB326CB4 /* PollingSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingSchedulerTests.swift; sourceTree = "<group>"; };
@@ -423,6 +425,7 @@
 				298318CA91C080E2C130A4DE /* LayoutEngineTests.swift */,
 				18F440861EC1F33CEB326CB4 /* PollingSchedulerTests.swift */,
 				12DCA371573CAAC4B23A96AA /* PrepareLayoutMutationTests.swift */,
+				14DFC0175B34415C25073FEA /* ResizeDirectionTests.swift */,
 				306A7B2B7B3F09F08F953F35 /* SuppressionRegistryTests.swift */,
 				3246386B0F502F2D858B3033 /* TileScratchpadTests.swift */,
 				DC08AAC03ABC15E772214598 /* ToggleSplitFallthroughRegressionTests.swift */,
@@ -674,6 +677,7 @@
 				15AB8B9331E6A03CDD991F3C /* LayoutEngineTests.swift in Sources */,
 				98D72FEBD5773242B4F199B7 /* PollingSchedulerTests.swift in Sources */,
 				CAF7E4C0660A5075D1D9DD62 /* PrepareLayoutMutationTests.swift in Sources */,
+				5AD7A1FCD49C5A8F5B749EE8 /* ResizeDirectionTests.swift in Sources */,
 				EDC0EDCDC01F4A5310E4A07E /* SuppressionRegistryTests.swift in Sources */,
 				8456B287CD1B9AC9E86336E5 /* TileScratchpadTests.swift in Sources */,
 				860959AD6A92DB57753D655E /* ToggleSplitFallthroughRegressionTests.swift in Sources */,

--- a/HyprMac/Core/KeybindOverlayController.swift
+++ b/HyprMac/Core/KeybindOverlayController.swift
@@ -304,13 +304,14 @@ private struct KeybindOverlayView: View {
     }
 
     // direction-bind families that coalesce into one arrow row
-    private enum DirFamily { case focus, swap, monitor }
+    private enum DirFamily { case focus, swap, monitor, resize }
 
     private func dirFamily(_ action: Action) -> DirFamily? {
         switch action {
         case .focusDirection:      return .focus
         case .swapDirection:       return .swap
         case .moveWindowToMonitor: return .monitor
+        case .resizeDirection:     return .resize
         default:                   return nil
         }
     }
@@ -319,7 +320,7 @@ private struct KeybindOverlayView: View {
     private func coalescedRow(from bind: Keybind, in binds: [Keybind],
                               consuming consumed: inout Set<Int>) -> OverlayRow? {
         switch bind.action {
-        case .focusDirection, .swapDirection, .moveWindowToMonitor:
+        case .focusDirection, .swapDirection, .moveWindowToMonitor, .resizeDirection:
             return directionRow(matching: bind, in: binds, consuming: &consumed)
         case .switchWorkspace, .moveToWorkspace:
             return workspaceRow(matching: bind, in: binds, consuming: &consumed)
@@ -342,6 +343,7 @@ private struct KeybindOverlayView: View {
             case .focusDirection(let d):      dir = d
             case .swapDirection(let d):       dir = d
             case .moveWindowToMonitor(let d): dir = d
+            case .resizeDirection(let d):     dir = d
             default:                          dir = nil
             }
             if let dir { arrows.append(dir); indices.append(j) }
@@ -357,6 +359,7 @@ private struct KeybindOverlayView: View {
         case .focus:   desc = "Focus direction"
         case .swap:    desc = "Swap direction"
         case .monitor: desc = "Move to monitor"
+        case .resize:  desc = "Resize window"
         }
         return OverlayRow(description: desc, chord: chord, isFloating: false)
     }

--- a/HyprMac/Core/Orchestration/ActionDispatcher.swift
+++ b/HyprMac/Core/Orchestration/ActionDispatcher.swift
@@ -195,6 +195,8 @@ final class ActionDispatcher {
             toggleScratchpad()
         case .moveToScratchpad:
             moveToScratchpad()
+        case .resizeDirection(let dir):
+            resizeInDirection(dir)
         }
 
         // let the Tour try-it hint (and any future observers) react. cheap —
@@ -222,6 +224,7 @@ final class ActionDispatcher {
         case .cycleWorkspace:      return "cycleWorkspace"
         case .toggleScratchpad:    return "toggleScratchpad"
         case .moveToScratchpad:    return "moveToScratchpad"
+        case .resizeDirection:     return "resizeDirection"
         }
     }
 
@@ -477,6 +480,17 @@ final class ActionDispatcher {
               let screen = displayManager.screen(for: focused) ?? displayManager.screens.first else { return }
         let workspace = workspaceManager.workspaceForScreen(screen)
         floatingController.toggle(focused, on: screen, in: workspace)
+    }
+
+    /// Resize the focused tiled window in a cardinal direction.
+    private func resizeInDirection(_ direction: Direction) {
+        guard let focused = currentFocusedWindow(),
+              !stateCache.floatingWindowIDs.contains(focused.windowID),
+              let screen = displayManager.screen(for: focused) ?? displayManager.screens.first else { return }
+        let workspace = workspaceManager.workspaceForScreen(screen)
+
+        tilingEngine.resizeInDirection(focused, direction: direction, onWorkspace: workspace, screen: screen)
+        updatePositionCache()
     }
 
     /// Toggle the BSP split direction at the focused leaf's parent.

--- a/HyprMac/Models/Action.swift
+++ b/HyprMac/Models/Action.swift
@@ -43,6 +43,10 @@ enum Action: Equatable {
     /// Send the focused window to the scratchpad (or put a summoned
     /// scratchpad window away — the key is symmetric).
     case moveToScratchpad
+    /// Resize the focused window in a cardinal direction by adjusting the
+    /// nearest matching-axis split ratio in the BSP tree. Hyprland parity:
+    /// `resizeactive`.
+    case resizeDirection(Direction)
 }
 
 // MARK: - Codable
@@ -79,6 +83,7 @@ extension Action: Codable {
         case cycleWorkspace
         case toggleScratchpad
         case moveToScratchpad
+        case resizeDirection
     }
 
     /// Accepted-but-not-emitted aliases. Lets a hand-edited config
@@ -137,6 +142,8 @@ extension Action: Codable {
         case .closeWindow:    self = .closeWindow
         case .toggleScratchpad: self = .toggleScratchpad
         case .moveToScratchpad: self = .moveToScratchpad
+        case .resizeDirection:
+            self = .resizeDirection(try Self.decodeDirection(inner, field: "resizeDirection"))
         }
     }
 
@@ -192,6 +199,9 @@ extension Action: Codable {
             _ = c.nestedContainer(keyedBy: PayloadKey.self, forKey: .toggleScratchpad)
         case .moveToScratchpad:
             _ = c.nestedContainer(keyedBy: PayloadKey.self, forKey: .moveToScratchpad)
+        case .resizeDirection(let d):
+            var p = c.nestedContainer(keyedBy: PayloadKey.self, forKey: .resizeDirection)
+            try p.encode(d.rawValue, forKey: ._0)
         }
     }
 }

--- a/HyprMac/Models/DefaultKeybinds.swift
+++ b/HyprMac/Models/DefaultKeybinds.swift
@@ -51,6 +51,16 @@ extension Keybind {
         binds.append(Keybind(keyCode: UInt16(kVK_RightArrow), modifiers: [.hypr, .control],
                              action: .moveWindowToMonitor(.right)))
 
+        // hypr + ctrl + shift + arrow: resize focused window in direction
+        binds.append(Keybind(keyCode: UInt16(kVK_LeftArrow), modifiers: [.hypr, .control, .shift],
+                             action: .resizeDirection(.left)))
+        binds.append(Keybind(keyCode: UInt16(kVK_RightArrow), modifiers: [.hypr, .control, .shift],
+                             action: .resizeDirection(.right)))
+        binds.append(Keybind(keyCode: UInt16(kVK_UpArrow), modifiers: [.hypr, .control, .shift],
+                             action: .resizeDirection(.up)))
+        binds.append(Keybind(keyCode: UInt16(kVK_DownArrow), modifiers: [.hypr, .control, .shift],
+                             action: .resizeDirection(.down)))
+
         // hypr + shift + t: toggle floating
         binds.append(Keybind(keyCode: UInt16(kVK_ANSI_T), modifiers: [.hypr, .shift],
                              action: .toggleFloating))

--- a/HyprMac/Settings/KeybindCategory.swift
+++ b/HyprMac/Settings/KeybindCategory.swift
@@ -18,7 +18,7 @@ enum KeybindCategory: String, CaseIterable {
         case .focusDirection, .focusFloating, .focusMenuBar:
             return .focusNav
         case .swapDirection, .toggleFloating, .toggleSplit, .closeWindow,
-             .toggleScratchpad, .moveToScratchpad:
+             .toggleScratchpad, .moveToScratchpad, .resizeDirection:
             return .windowManagement
         case .switchWorkspace, .moveToWorkspace, .moveWindowToMonitor, .cycleWorkspace:
             return .workspaces

--- a/HyprMac/Settings/KeybindDisplayHelpers.swift
+++ b/HyprMac/Settings/KeybindDisplayHelpers.swift
@@ -55,6 +55,8 @@ extension Keybind {
             return "tray"
         case .moveToScratchpad:
             return "tray.and.arrow.down"
+        case .resizeDirection:
+            return "arrow.up.left.and.arrow.down.right"
         }
     }
 
@@ -85,6 +87,7 @@ extension Keybind {
         case .cycleWorkspace(let d):        return d > 0 ? "Next Workspace" : "Previous Workspace"
         case .toggleScratchpad:             return "Toggle Scratchpad"
         case .moveToScratchpad:             return "Send to Scratchpad"
+        case .resizeDirection(let d):       return "Resize \(d.rawValue.capitalized)"
         }
     }
 }

--- a/HyprMac/Settings/KeybindEditorViewModel.swift
+++ b/HyprMac/Settings/KeybindEditorViewModel.swift
@@ -37,6 +37,7 @@ final class KeybindEditorViewModel: ObservableObject {
         case cycleWorkspace         = "Cycle Workspace"
         case toggleScratchpad       = "Toggle Scratchpad"
         case moveToScratchpad       = "Send to Scratchpad"
+        case resizeDirection        = "Resize Direction"
     }
 
     var canSave: Bool { recordedKeyCode != 0 }
@@ -65,6 +66,7 @@ final class KeybindEditorViewModel: ObservableObject {
         case .cycleWorkspace(let d):         selectedAction = .cycleWorkspace;         workspaceParam = d
         case .toggleScratchpad:              selectedAction = .toggleScratchpad
         case .moveToScratchpad:              selectedAction = .moveToScratchpad
+        case .resizeDirection(let d):        selectedAction = .resizeDirection;       directionParam = d
         }
     }
 
@@ -90,6 +92,7 @@ final class KeybindEditorViewModel: ObservableObject {
         case .cycleWorkspace:         action = .cycleWorkspace(workspaceParam)
         case .toggleScratchpad:       action = .toggleScratchpad
         case .moveToScratchpad:       action = .moveToScratchpad
+        case .resizeDirection:        action = .resizeDirection(directionParam)
         }
         return Keybind(keyCode: recordedKeyCode, modifiers: mods, action: action)
     }

--- a/HyprMac/Settings/KeybindsSettingsView.swift
+++ b/HyprMac/Settings/KeybindsSettingsView.swift
@@ -334,7 +334,7 @@ struct KeybindEditorSheet: View {
                 .labelsHidden()
 
                 switch vm.selectedAction {
-                case .focusDirection, .swapDirection, .moveWindowToMonitor:
+                case .focusDirection, .swapDirection, .moveWindowToMonitor, .resizeDirection:
                     DirectionPicker(direction: $vm.directionParam)
                 case .switchWorkspace, .moveToWorkspace:
                     WorkspacePicker(workspace: $vm.workspaceParam)

--- a/HyprMac/Tiling/TilingConfig.swift
+++ b/HyprMac/Tiling/TilingConfig.swift
@@ -41,6 +41,9 @@ enum TilingConfig {
     // avoids no-op AX writes triggered by sub-pixel jitter during manual resize.
     static let manualResizeRatioTolerance: CGFloat = 0.01
 
+    // step size for keyboard-driven resize (resizeDirection action).
+    static let resizeStep: CGFloat = 0.05
+
     // MARK: - min-size memory
 
     // slack on min-size conflict comparisons in BSPTree.adjustForMinSizes.

--- a/HyprMac/Tiling/TilingEngine.swift
+++ b/HyprMac/Tiling/TilingEngine.swift
@@ -940,6 +940,47 @@ class TilingEngine {
         retile(key: key, screen: screen)
     }
 
+    /// Resize the focused window by adjusting the nearest matching-axis
+    /// split ratio. Walks from the leaf upward to find the first ancestor
+    /// whose split direction matches the resize axis, then nudges its
+    /// `splitRatio` by `step`. Flags the ancestor `userSetRatio = true`
+    /// so the adjustment survives retiles.
+    func resizeInDirection(_ window: HyprWindow, direction: Direction,
+                           onWorkspace workspace: Int, screen: NSScreen) {
+        let key = TilingKey(workspace: workspace, screen: screen)
+        let t = tree(for: key)
+        let rect = displayManager.cgRect(for: screen)
+        let padded = rect.insetBy(dx: outerPadding, dy: outerPadding)
+
+        guard let leaf = t.root.find(window) else { return }
+
+        let axis: SplitDirection = (direction == .left || direction == .right) ? .horizontal : .vertical
+        let grow = (direction == .right || direction == .down)
+
+        let step: CGFloat = 0.05
+
+        var node = leaf
+        while let parent = node.parent {
+            guard let parentRect = t.rectForNode(parent, in: rect, gap: gapSize, padding: outerPadding) else {
+                node = parent
+                continue
+            }
+            guard parent.direction(for: parentRect) == axis else {
+                node = parent
+                continue
+            }
+
+            let isLeft = parent.left === node
+            let delta: CGFloat = (isLeft == grow) ? step : -step
+            parent.splitRatio += delta
+            parent.userSetRatio = true
+            hyprLog(.debug, .orchestration, "resizeDirection \(direction): ratio → \(String(format: "%.2f", parent.splitRatio))")
+            break
+        }
+
+        retile(key: key, screen: screen)
+    }
+
     /// Toggle the split direction of `window`'s parent and return post-toggle
     /// layout rects without applying frames.
     ///

--- a/HyprMac/Tiling/TilingEngine.swift
+++ b/HyprMac/Tiling/TilingEngine.swift
@@ -950,12 +950,11 @@ class TilingEngine {
         let key = TilingKey(workspace: workspace, screen: screen)
         let t = tree(for: key)
         let rect = displayManager.cgRect(for: screen)
-        let padded = rect.insetBy(dx: outerPadding, dy: outerPadding)
 
         guard let leaf = t.root.find(window) else { return }
 
         let axis: SplitDirection = (direction == .left || direction == .right) ? .horizontal : .vertical
-        let grow = (direction == .right || direction == .down)
+        let positive = (direction == .right || direction == .down)
 
         let step: CGFloat = 0.05
 
@@ -970,8 +969,7 @@ class TilingEngine {
                 continue
             }
 
-            let isLeft = parent.left === node
-            let delta: CGFloat = (isLeft == grow) ? step : -step
+            let delta: CGFloat = positive ? step : -step
             parent.splitRatio += delta
             parent.userSetRatio = true
             hyprLog(.debug, .orchestration, "resizeDirection \(direction): ratio → \(String(format: "%.2f", parent.splitRatio))")

--- a/HyprMac/Tiling/TilingEngine.swift
+++ b/HyprMac/Tiling/TilingEngine.swift
@@ -956,9 +956,8 @@ class TilingEngine {
         let axis: SplitDirection = (direction == .left || direction == .right) ? .horizontal : .vertical
         let positive = (direction == .right || direction == .down)
 
-        let step: CGFloat = 0.05
-
         var node = leaf
+        var didResize = false
         while let parent = node.parent {
             guard let parentRect = t.rectForNode(parent, in: rect, gap: gapSize, padding: outerPadding) else {
                 node = parent
@@ -969,14 +968,21 @@ class TilingEngine {
                 continue
             }
 
-            let delta: CGFloat = positive ? step : -step
-            parent.splitRatio += delta
+            let isLeft = parent.left === node
+            let grow = isLeft == positive
+            let delta: CGFloat = grow ? TilingConfig.resizeStep : -TilingConfig.resizeStep
+            let newRatio = min(max(parent.splitRatio + delta, TilingConfig.minRatio), TilingConfig.maxRatio)
+            guard newRatio != parent.splitRatio else { break }
+            parent.splitRatio = newRatio
             parent.userSetRatio = true
-            hyprLog(.debug, .orchestration, "resizeDirection \(direction): ratio → \(String(format: "%.2f", parent.splitRatio))")
+            didResize = true
+            hyprLog(.debug, .tiling, "resizeDirection \(direction): ratio → \(String(format: "%.2f", newRatio))")
             break
         }
 
-        retile(key: key, screen: screen)
+        if didResize {
+            retile(key: key, screen: screen)
+        }
     }
 
     /// Toggle the split direction of `window`'s parent and return post-toggle

--- a/HyprMacTests/ResizeDirectionTests.swift
+++ b/HyprMacTests/ResizeDirectionTests.swift
@@ -60,6 +60,36 @@ final class ResizeDirectionTests: XCTestCase {
                        "resize step should be 0.05")
     }
 
+    // MARK: - right child resize
+
+    func testRightChildResizeRightGrowsRightChild() {
+        let a = makeWindow(id: 1)
+        let b = makeWindow(id: 2)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+
+        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
+        let ratioBefore = tree.root.splitRatio
+
+        engine.resizeInDirection(b, direction: .right, onWorkspace: 1, screen: screen)
+
+        XCTAssertLessThan(tree.root.splitRatio, ratioBefore,
+                          "right child pressing right should decrease ratio (grow right child)")
+    }
+
+    func testRightChildResizeLeftShrinksRightChild() {
+        let a = makeWindow(id: 1)
+        let b = makeWindow(id: 2)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+
+        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
+        let ratioBefore = tree.root.splitRatio
+
+        engine.resizeInDirection(b, direction: .left, onWorkspace: 1, screen: screen)
+
+        XCTAssertGreaterThan(tree.root.splitRatio, ratioBefore,
+                             "right child pressing left should increase ratio (shrink right child)")
+    }
+
     // MARK: - axis matching
 
     func testResizeWalksUpToMatchingAxis() {

--- a/HyprMacTests/ResizeDirectionTests.swift
+++ b/HyprMacTests/ResizeDirectionTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+import Cocoa
+@testable import HyprMac
+
+final class ResizeDirectionTests: XCTestCase {
+
+    private var displayManager: DisplayManager!
+    private var engine: TilingEngine!
+    private var screen: NSScreen!
+
+    override func setUpWithError() throws {
+        displayManager = DisplayManager()
+        engine = TilingEngine(displayManager: displayManager)
+        guard let main = NSScreen.main ?? NSScreen.screens.first else {
+            throw XCTSkip("no NSScreen available — test requires a display")
+        }
+        screen = main
+    }
+
+    // MARK: - horizontal resize
+
+    func testResizeRightIncreasesRatio() {
+        let a = makeWindow(id: 1)
+        let b = makeWindow(id: 2)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+
+        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
+        let ratioBefore = tree.root.splitRatio
+
+        engine.resizeInDirection(a, direction: .right, onWorkspace: 1, screen: screen)
+
+        XCTAssertGreaterThan(tree.root.splitRatio, ratioBefore)
+        XCTAssertTrue(tree.root.userSetRatio)
+    }
+
+    func testResizeLeftDecreasesRatio() {
+        let a = makeWindow(id: 1)
+        let b = makeWindow(id: 2)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+
+        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
+        let ratioBefore = tree.root.splitRatio
+
+        engine.resizeInDirection(a, direction: .left, onWorkspace: 1, screen: screen)
+
+        XCTAssertLessThan(tree.root.splitRatio, ratioBefore)
+        XCTAssertTrue(tree.root.userSetRatio)
+    }
+
+    func testResizeStepSize() {
+        let a = makeWindow(id: 1)
+        let b = makeWindow(id: 2)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+
+        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
+
+        engine.resizeInDirection(a, direction: .right, onWorkspace: 1, screen: screen)
+
+        XCTAssertEqual(tree.root.splitRatio, 0.55, accuracy: 0.001,
+                       "resize step should be 0.05")
+    }
+
+    // MARK: - axis matching
+
+    func testResizeWalksUpToMatchingAxis() {
+        // three windows: root splits horizontal, one child splits vertical.
+        // resizing vertically on the deeper child should walk past the
+        // horizontal root to find a vertical ancestor — but with only
+        // horizontal splits, a vertical resize is a no-op.
+        let a = makeWindow(id: 1)
+        let b = makeWindow(id: 2)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+
+        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
+        let ratioBefore = tree.root.splitRatio
+
+        // on a wide screen the root splits horizontally.
+        // resizing up/down should find no vertical ancestor — ratio unchanged.
+        engine.resizeInDirection(a, direction: .up, onWorkspace: 1, screen: screen)
+
+        XCTAssertEqual(tree.root.splitRatio, ratioBefore, accuracy: 0.001,
+                       "perpendicular resize should be a no-op when no matching axis ancestor exists")
+    }
+
+    // MARK: - clamping
+
+    func testResizeRespectsClamping() {
+        let a = makeWindow(id: 1)
+        let b = makeWindow(id: 2)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+
+        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
+
+        // push ratio to the upper clamp
+        for _ in 0..<20 {
+            engine.resizeInDirection(a, direction: .right, onWorkspace: 1, screen: screen)
+        }
+        XCTAssertLessThanOrEqual(tree.root.splitRatio, 0.85,
+                                 "ratio should be clamped at 0.85")
+
+        // push ratio to the lower clamp
+        for _ in 0..<30 {
+            engine.resizeInDirection(a, direction: .left, onWorkspace: 1, screen: screen)
+        }
+        XCTAssertGreaterThanOrEqual(tree.root.splitRatio, 0.15,
+                                    "ratio should be clamped at 0.15")
+    }
+
+    // MARK: - no-op on missing window
+
+    func testResizeUnknownWindowIsNoop() {
+        let a = makeWindow(id: 1)
+        let b = makeWindow(id: 2)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+
+        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
+        let ratioBefore = tree.root.splitRatio
+
+        let stranger = makeWindow(id: 99)
+        engine.resizeInDirection(stranger, direction: .right, onWorkspace: 1, screen: screen)
+
+        XCTAssertEqual(tree.root.splitRatio, ratioBefore, accuracy: 0.001)
+    }
+
+    // MARK: - defaults coverage
+
+    func testDefaultsContainAllResizeDirections() {
+        var dirs: Set<Direction> = []
+        for kb in Keybind.defaults {
+            if case .resizeDirection(let d) = kb.action { dirs.insert(d) }
+        }
+        XCTAssertEqual(dirs, Set([.left, .right, .up, .down]))
+    }
+
+    func testResizeDirectionActionRoundTrips() throws {
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        for dir in [Direction.left, .right, .up, .down] {
+            let kb = Keybind(keyCode: 123, modifiers: .hypr, action: .resizeDirection(dir))
+            let data = try encoder.encode(kb)
+            let decoded = try decoder.decode(Keybind.self, from: data)
+            XCTAssertEqual(decoded.action, kb.action)
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The physical Hypr key is configurable in Settings → General. Options include C
 | `⇪ + 1–9` | Switch to workspace N |
 | `⇪ + ⇧ + 1–9` | Move window to workspace N |
 | `⇪ + ⌃ + ←/→` | Move window to adjacent monitor |
+| `⇪ + ⌃ + ⇧ + ←/→/↑/↓` | Resize focused window in direction |
 | `⇪ + ⇥` / `⇪ + ⇧ + ⇥` | Cycle occupied workspaces on current monitor |
 | `⇪ + W` | Close window |
 | `⇪ + K` | Show keybind overlay |

--- a/docs/keybinds-and-actions.md
+++ b/docs/keybinds-and-actions.md
@@ -22,6 +22,7 @@ enum Action: Equatable {
     case focusFloating
     case closeWindow
     case cycleWorkspace(Int)
+    case resizeDirection(Direction)
 }
 ```
 


### PR DESCRIPTION
## Summary

Adds keyboard-driven window resizing to HyprMac, addressing #8. The implementation follows Hyprland's `resizeactive` model — arrow keys move the nearest matching-axis BSP split boundary.

### Changes

- **New action**: `resizeDirection(Direction)` with full Codable support (wire key: `"resizeDirection"`)
- **BSP resize logic** (`TilingEngine.resizeInDirection`): walks from the focused leaf up the tree to find the first ancestor whose split direction matches the resize axis, then nudges `splitRatio` by ±0.05. Sets `userSetRatio = true` so the adjustment survives retiles
- **Default keybinds**: `Hypr+Ctrl+Shift+←→↑↓` (avoids conflict with existing `Hypr+Ctrl+←→` for moveWindowToMonitor)
- **Keybind overlay**: resize directions are coalesced into a single "Resize window" row (matching focus/swap presentation)
- **Settings UI**: full round-trip support in the keybind editor, category classification (Window Management), icon and description

### Behaviour

The arrow direction moves the **split boundary** in that direction — this is position-independent (same behaviour regardless of which side of the split the focused window is on). Ratio is clamped to `[TilingConfig.minRatio, TilingConfig.maxRatio]` by the existing BSPNode setter.

### Testing

Built and tested locally on macOS Tahoe (26.5) with 3 monitors. Resize works on horizontal and vertical splits at any tree depth. `userSetRatio` flag correctly preserves manual resizes across retiles.