### PR TITLE
feat: per-window BSP ratio memory across tab switches

### DIFF
--- a/HyprMac.xcodeproj/project.pbxproj
+++ b/HyprMac.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		0086DBE1974C316B4B7AE242 /* ColorPickerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F2F88E3A815333F6542EEA /* ColorPickerRow.swift */; };
 		00B50053F139D098B090709F /* WindowDiscoveryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857FCC6A226AFEECD7A199FC /* WindowDiscoveryServiceTests.swift */; };
 		049A911F001515424E52E5B9 /* BSPNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AC17310FABAC0CFEA327E7 /* BSPNodeTests.swift */; };
-		5B18E25A4DC594C18C2A461F /* RatioMemoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E40B9E65619703E1B9E2293 /* RatioMemoryTests.swift */; };
 		0A95C40458C159F8851E03E4 /* BSPTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A85F3FF392095FDDB36DAB7 /* BSPTestSupport.swift */; };
 		0B9D198B68374BB6E0D0FA1F /* DragManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E56F3B2C9834C78368323D /* DragManager.swift */; };
 		0D4C6B4D33142A677A590C35 /* DisplayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593D96A7340421A4588DE5D5 /* DisplayManager.swift */; };
@@ -20,6 +19,7 @@
 		15AB8B9331E6A03CDD991F3C /* LayoutEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 298318CA91C080E2C130A4DE /* LayoutEngineTests.swift */; };
 		16658F8479CAE2DD07B18DB5 /* FocusStateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB845A902D1A884872996805 /* FocusStateController.swift */; };
 		188EAF405D36CBFCDAB54014 /* Keybind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E4E656D3CA021B130775CC3 /* Keybind.swift */; };
+		192896C26681E7F32D0A8EE3 /* RatioMemoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B508954B7CC67DE0AB417D2E /* RatioMemoryTests.swift */; };
 		1B637997E721C7D6BF0FC307 /* DirectionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301C7EDAAD234FC3DDCBAADC /* DirectionPicker.swift */; };
 		1CE8BFDB73C690ADABECD3C3 /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23220FDBA7BCF857E8EBC0F0 /* MenuBarView.swift */; };
 		1D5547D2D6368BB0D2355F0E /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E1DEE768A398E963AAB1CA /* DesignSystem.swift */; };
@@ -122,7 +122,6 @@
 		0B9CF795BFCF2AE866D59470 /* KeybindsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindsSettingsView.swift; sourceTree = "<group>"; };
 		12DCA371573CAAC4B23A96AA /* PrepareLayoutMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepareLayoutMutationTests.swift; sourceTree = "<group>"; };
 		16AC17310FABAC0CFEA327E7 /* BSPNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BSPNodeTests.swift; sourceTree = "<group>"; };
-		9E40B9E65619703E1B9E2293 /* RatioMemoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatioMemoryTests.swift; sourceTree = "<group>"; };
 		17ABB08FA82CF475A82AB3C5 /* KeybindEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindEditorViewModel.swift; sourceTree = "<group>"; };
 		18F440861EC1F33CEB326CB4 /* PollingSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingSchedulerTests.swift; sourceTree = "<group>"; };
 		1A029C0AE0E8E5DEE2416684 /* UserConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserConfig.swift; sourceTree = "<group>"; };
@@ -181,6 +180,7 @@
 		A7BD70717FD497B0899FBCE5 /* KeybindOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindOverlayController.swift; sourceTree = "<group>"; };
 		AF93D6331BC4826814BB7007 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		B38E1F4DBD1DB2807610AB4E /* FocusBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusBorder.swift; sourceTree = "<group>"; };
+		B508954B7CC67DE0AB417D2E /* RatioMemoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatioMemoryTests.swift; sourceTree = "<group>"; };
 		B6FC3298BBD003F3AD7DAC44 /* WindowCornerRadius.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCornerRadius.swift; sourceTree = "<group>"; };
 		B9927DB9594D281BB5179CA3 /* LayoutEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutEngine.swift; sourceTree = "<group>"; };
 		BB697B2619BEB7E2434E157E /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
@@ -425,7 +425,7 @@
 				298318CA91C080E2C130A4DE /* LayoutEngineTests.swift */,
 				18F440861EC1F33CEB326CB4 /* PollingSchedulerTests.swift */,
 				12DCA371573CAAC4B23A96AA /* PrepareLayoutMutationTests.swift */,
-				9E40B9E65619703E1B9E2293 /* RatioMemoryTests.swift */,
+				B508954B7CC67DE0AB417D2E /* RatioMemoryTests.swift */,
 				306A7B2B7B3F09F08F953F35 /* SuppressionRegistryTests.swift */,
 				3246386B0F502F2D858B3033 /* TileScratchpadTests.swift */,
 				DC08AAC03ABC15E772214598 /* ToggleSplitFallthroughRegressionTests.swift */,
@@ -677,7 +677,7 @@
 				15AB8B9331E6A03CDD991F3C /* LayoutEngineTests.swift in Sources */,
 				98D72FEBD5773242B4F199B7 /* PollingSchedulerTests.swift in Sources */,
 				CAF7E4C0660A5075D1D9DD62 /* PrepareLayoutMutationTests.swift in Sources */,
-				5B18E25A4DC594C18C2A461F /* RatioMemoryTests.swift in Sources */,
+				192896C26681E7F32D0A8EE3 /* RatioMemoryTests.swift in Sources */,
 				EDC0EDCDC01F4A5310E4A07E /* SuppressionRegistryTests.swift in Sources */,
 				8456B287CD1B9AC9E86336E5 /* TileScratchpadTests.swift in Sources */,
 				860959AD6A92DB57753D655E /* ToggleSplitFallthroughRegressionTests.swift in Sources */,

--- a/HyprMac.xcodeproj/project.pbxproj
+++ b/HyprMac.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0086DBE1974C316B4B7AE242 /* ColorPickerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F2F88E3A815333F6542EEA /* ColorPickerRow.swift */; };
 		00B50053F139D098B090709F /* WindowDiscoveryServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 857FCC6A226AFEECD7A199FC /* WindowDiscoveryServiceTests.swift */; };
 		049A911F001515424E52E5B9 /* BSPNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AC17310FABAC0CFEA327E7 /* BSPNodeTests.swift */; };
+		5B18E25A4DC594C18C2A461F /* RatioMemoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E40B9E65619703E1B9E2293 /* RatioMemoryTests.swift */; };
 		0A95C40458C159F8851E03E4 /* BSPTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A85F3FF392095FDDB36DAB7 /* BSPTestSupport.swift */; };
 		0B9D198B68374BB6E0D0FA1F /* DragManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E56F3B2C9834C78368323D /* DragManager.swift */; };
 		0D4C6B4D33142A677A590C35 /* DisplayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593D96A7340421A4588DE5D5 /* DisplayManager.swift */; };
@@ -68,7 +69,6 @@
 		98D72FEBD5773242B4F199B7 /* PollingSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18F440861EC1F33CEB326CB4 /* PollingSchedulerTests.swift */; };
 		9D75A3D3BAA41C0012711D6D /* UserConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A029C0AE0E8E5DEE2416684 /* UserConfig.swift */; };
 		A34F6208901205B1100F08AE /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB697B2619BEB7E2434E157E /* WelcomeView.swift */; };
-		A78F1FAAB49BEEEAE2A1844D /* ResizeDirectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E97E23BFC7B85A7E6BF506 /* ResizeDirectionTests.swift */; };
 		AC01521BE9F2030CF901A2C9 /* DragSwapHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB2A500B78D0C9A7FAE6173 /* DragSwapHandler.swift */; };
 		B44C416E3958C82361083048 /* KeybindOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7BD70717FD497B0899FBCE5 /* KeybindOverlayController.swift */; };
 		B6C40B2479058C399AD8153B /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5627CA2ADE2AA85B3372EB81 /* SettingsView.swift */; };
@@ -122,6 +122,7 @@
 		0B9CF795BFCF2AE866D59470 /* KeybindsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindsSettingsView.swift; sourceTree = "<group>"; };
 		12DCA371573CAAC4B23A96AA /* PrepareLayoutMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepareLayoutMutationTests.swift; sourceTree = "<group>"; };
 		16AC17310FABAC0CFEA327E7 /* BSPNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BSPNodeTests.swift; sourceTree = "<group>"; };
+		9E40B9E65619703E1B9E2293 /* RatioMemoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatioMemoryTests.swift; sourceTree = "<group>"; };
 		17ABB08FA82CF475A82AB3C5 /* KeybindEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindEditorViewModel.swift; sourceTree = "<group>"; };
 		18F440861EC1F33CEB326CB4 /* PollingSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingSchedulerTests.swift; sourceTree = "<group>"; };
 		1A029C0AE0E8E5DEE2416684 /* UserConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserConfig.swift; sourceTree = "<group>"; };
@@ -152,7 +153,6 @@
 		5C0116BE6F796AC619B0BD6B /* CoordinateSpace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateSpace.swift; sourceTree = "<group>"; };
 		61E1DEE768A398E963AAB1CA /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
 		63E30549B7EABECD4FCDBC0F /* BundleIDUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleIDUtils.swift; sourceTree = "<group>"; };
-		64E97E23BFC7B85A7E6BF506 /* ResizeDirectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizeDirectionTests.swift; sourceTree = "<group>"; };
 		65F2F88E3A815333F6542EEA /* ColorPickerRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerRow.swift; sourceTree = "<group>"; };
 		6B23E3313247FD77173D35DD /* DefaultKeybindsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultKeybindsTests.swift; sourceTree = "<group>"; };
 		6E4E656D3CA021B130775CC3 /* Keybind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keybind.swift; sourceTree = "<group>"; };
@@ -425,7 +425,7 @@
 				298318CA91C080E2C130A4DE /* LayoutEngineTests.swift */,
 				18F440861EC1F33CEB326CB4 /* PollingSchedulerTests.swift */,
 				12DCA371573CAAC4B23A96AA /* PrepareLayoutMutationTests.swift */,
-				64E97E23BFC7B85A7E6BF506 /* ResizeDirectionTests.swift */,
+				9E40B9E65619703E1B9E2293 /* RatioMemoryTests.swift */,
 				306A7B2B7B3F09F08F953F35 /* SuppressionRegistryTests.swift */,
 				3246386B0F502F2D858B3033 /* TileScratchpadTests.swift */,
 				DC08AAC03ABC15E772214598 /* ToggleSplitFallthroughRegressionTests.swift */,
@@ -677,7 +677,7 @@
 				15AB8B9331E6A03CDD991F3C /* LayoutEngineTests.swift in Sources */,
 				98D72FEBD5773242B4F199B7 /* PollingSchedulerTests.swift in Sources */,
 				CAF7E4C0660A5075D1D9DD62 /* PrepareLayoutMutationTests.swift in Sources */,
-				A78F1FAAB49BEEEAE2A1844D /* ResizeDirectionTests.swift in Sources */,
+				5B18E25A4DC594C18C2A461F /* RatioMemoryTests.swift in Sources */,
 				EDC0EDCDC01F4A5310E4A07E /* SuppressionRegistryTests.swift in Sources */,
 				8456B287CD1B9AC9E86336E5 /* TileScratchpadTests.swift in Sources */,
 				860959AD6A92DB57753D655E /* ToggleSplitFallthroughRegressionTests.swift in Sources */,
@@ -868,7 +868,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 81;
+				CURRENT_PROJECT_VERSION = 77;
 				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
 				ENABLE_HARDENED_RUNTIME = NO;
 				INFOPLIST_FILE = HyprMac/Info.plist;
@@ -876,7 +876,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
+				MARKETING_VERSION = 0.10.2;
 				OTHER_LDFLAGS = (
 					"-F/System/Library/PrivateFrameworks",
 					"-framework",
@@ -895,7 +895,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 81;
+				CURRENT_PROJECT_VERSION = 77;
 				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
 				ENABLE_HARDENED_RUNTIME = NO;
 				INFOPLIST_FILE = HyprMac/Info.plist;
@@ -903,7 +903,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
+				MARKETING_VERSION = 0.10.2;
 				OTHER_LDFLAGS = (
 					"-F/System/Library/PrivateFrameworks",
 					"-framework",

--- a/HyprMac/Core/WindowManager.swift
+++ b/HyprMac/Core/WindowManager.swift
@@ -1889,6 +1889,7 @@ class WindowManager {
     /// or border state that pointed at the window.
     private func applyForgottenIDExternalCleanup(_ id: CGWindowID) {
         tilingEngine.forgetMinimumSize(windowID: id)
+        tilingEngine.forgetSavedRatio(windowID: id)
         workspaceManager.removeWindow(id)
         scratchpad.forget(id)
         if focusController.lastFocusedID == id {

--- a/HyprMac/Core/WindowManager.swift
+++ b/HyprMac/Core/WindowManager.swift
@@ -1889,7 +1889,6 @@ class WindowManager {
     /// or border state that pointed at the window.
     private func applyForgottenIDExternalCleanup(_ id: CGWindowID) {
         tilingEngine.forgetMinimumSize(windowID: id)
-        tilingEngine.forgetSavedRatio(windowID: id)
         workspaceManager.removeWindow(id)
         scratchpad.forget(id)
         if focusController.lastFocusedID == id {

--- a/HyprMac/Tiling/BSPNode.swift
+++ b/HyprMac/Tiling/BSPNode.swift
@@ -49,6 +49,9 @@ class BSPNode {
     var left: BSPNode?
     var right: BSPNode?
 
+    var savedSplitRatio: CGFloat?
+    var savedChildWasLeft: Bool?
+
     /// `true` for terminal nodes — see file-level invariants.
     var isLeaf: Bool { window != nil || (left == nil && right == nil) }
 
@@ -76,16 +79,30 @@ class BSPNode {
         guard isLeaf else { return }
 
         let existing = self.window
+        let savedRatio = self.savedSplitRatio
+        let savedWasLeft = self.savedChildWasLeft
+
         self.window = nil
         self.splitRatio = TilingConfig.defaultRatio
         self.userSetRatio = false
         self.splitOverride = nil
+        self.savedSplitRatio = nil
+        self.savedChildWasLeft = nil
 
-        self.left = BSPNode(window: existing)
+        if let wasLeft = savedWasLeft, wasLeft {
+            self.left = BSPNode(window: newWindow)
+            self.right = BSPNode(window: existing)
+        } else {
+            self.left = BSPNode(window: existing)
+            self.right = BSPNode(window: newWindow)
+        }
         self.left?.parent = self
-
-        self.right = BSPNode(window: newWindow)
         self.right?.parent = self
+
+        if let ratio = savedRatio, let wasLeft = savedWasLeft {
+            self.savedSplitRatio = ratio
+            self.savedChildWasLeft = wasLeft
+        }
     }
 
     /// Remove this leaf and promote its sibling into the parent slot.
@@ -96,7 +113,13 @@ class BSPNode {
     func remove() {
         guard let parent = parent else { return }
 
-        let sibling = (parent.left === self) ? parent.right : parent.left
+        let wasLeft = parent.left === self
+        let sibling = wasLeft ? parent.right : parent.left
+
+        if parent.userSetRatio || parent.splitRatio != TilingConfig.defaultRatio {
+            sibling?.savedSplitRatio = parent.splitRatio
+            sibling?.savedChildWasLeft = wasLeft
+        }
 
         parent.window = sibling?.window
         parent.left = sibling?.left
@@ -104,6 +127,8 @@ class BSPNode {
         parent.splitRatio = sibling?.splitRatio ?? TilingConfig.defaultRatio
         parent.userSetRatio = sibling?.userSetRatio ?? false
         parent.splitOverride = sibling?.splitOverride
+        parent.savedSplitRatio = sibling?.savedSplitRatio
+        parent.savedChildWasLeft = sibling?.savedChildWasLeft
 
         parent.left?.parent = parent
         parent.right?.parent = parent
@@ -114,6 +139,20 @@ class BSPNode {
     func find(_ target: HyprWindow) -> BSPNode? {
         if window == target { return self }
         return left?.find(target) ?? right?.find(target)
+    }
+
+    /// Apply any pending saved ratios stored during insert, then
+    /// recurse into children. Called after clearUserSetRatios +
+    /// resetSplitRatios so restored ratios survive the reset.
+    func applySavedRatios() {
+        if !isLeaf, let ratio = savedSplitRatio, let _ = savedChildWasLeft {
+            self.splitRatio = ratio
+            self.userSetRatio = true
+            self.savedSplitRatio = nil
+            self.savedChildWasLeft = nil
+        }
+        left?.applySavedRatios()
+        right?.applySavedRatios()
     }
 
     /// Reset every internal node's `splitRatio` to the default, except

--- a/HyprMac/Tiling/TilingEngine.swift
+++ b/HyprMac/Tiling/TilingEngine.swift
@@ -65,15 +65,6 @@ class TilingEngine {
 
     private let minSizes = MinSizeMemory()
 
-    /// Per-window saved split ratio. When a window leaves the tree
-    /// (tab switch, hide), its parent's `splitRatio` and the window's
-    /// child position are recorded here. On re-insert the ratio is
-    /// restored so the user's manual resize survives tab switches.
-    private struct SavedRatio {
-        let ratio: CGFloat
-        let wasLeftChild: Bool
-    }
-    private var savedRatios: [CGWindowID: SavedRatio] = [:]
 
     init(displayManager: DisplayManager) {
         self.displayManager = displayManager
@@ -98,35 +89,9 @@ class TilingEngine {
     func removeWindowID(_ windowID: CGWindowID) {
         for (_, t) in trees {
             guard let w = t.allWindows.first(where: { $0.windowID == windowID }) else { continue }
-            saveRatioBeforeRemoval(window: w, in: t)
             t.remove(w)
             t.root.pruneEmptyNodes()
             return
-        }
-    }
-
-    /// Drop any saved ratio for `windowID`. Called alongside
-    /// `forgetMinimumSize` when a window is truly gone (app quit).
-    func forgetSavedRatio(windowID: CGWindowID) { savedRatios.removeValue(forKey: windowID) }
-
-    private func saveRatioBeforeRemoval(window: HyprWindow, in tree: BSPTree) {
-        guard let node = tree.root.find(window) else { return }
-        guard let parent = node.parent else { return }
-        guard parent.splitRatio != TilingConfig.defaultRatio || parent.userSetRatio else { return }
-        let isLeft = parent.left === node
-        savedRatios[window.windowID] = SavedRatio(ratio: parent.splitRatio, wasLeftChild: isLeft)
-    }
-
-    /// Restore saved ratios for windows present in the tree.
-    /// Called after insert + ratio reset so restored ratios are not wiped.
-    private func restoreSavedRatios(in tree: BSPTree) {
-        for window in tree.allWindows {
-            guard let saved = savedRatios.removeValue(forKey: window.windowID) else { continue }
-            guard let node = tree.root.find(window), let parent = node.parent else { continue }
-            let isLeft = parent.left === node
-            let ratio = (isLeft == saved.wasLeftChild) ? saved.ratio : (1.0 - saved.ratio)
-            parent.splitRatio = ratio
-            parent.userSetRatio = true
         }
     }
 
@@ -388,7 +353,6 @@ class TilingEngine {
         let treeIDs = Set(treeWindows.map { $0.windowID })
 
         for w in treeWindows where !currentIDs.contains(w.windowID) {
-            saveRatioBeforeRemoval(window: w, in: t)
             t.remove(w)
         }
 
@@ -431,7 +395,8 @@ class TilingEngine {
             t.root.clearUserSetRatios()
             t.root.resetSplitRatios()
         }
-        restoreSavedRatios(in: t)
+        t.root.applySavedRatios()
+
         return TileMembershipResult(key: key, tree: t, rect: rect, insertedWindows: insertedWindows)
     }
 
@@ -523,7 +488,6 @@ class TilingEngine {
 
         // membership diff: remove gone (sibling promotion keeps shape), insert new
         for w in treeWindows where !currentIDs.contains(w.windowID) {
-            saveRatioBeforeRemoval(window: w, in: t)
             t.remove(w)
         }
         t.root.pruneEmptyNodes()
@@ -538,7 +502,8 @@ class TilingEngine {
         }
 
         t.root.resetSplitRatios()
-        restoreSavedRatios(in: t)
+        t.root.applySavedRatios()
+
         let layouts = t.layout(in: rect, gap: gapSize, padding: outerPadding)
         let conflicts = applyLayout(layouts)
         if !conflicts.isEmpty {

--- a/HyprMac/Tiling/TilingEngine.swift
+++ b/HyprMac/Tiling/TilingEngine.swift
@@ -65,6 +65,16 @@ class TilingEngine {
 
     private let minSizes = MinSizeMemory()
 
+    /// Per-window saved split ratio. When a window leaves the tree
+    /// (tab switch, hide), its parent's `splitRatio` and the window's
+    /// child position are recorded here. On re-insert the ratio is
+    /// restored so the user's manual resize survives tab switches.
+    private struct SavedRatio {
+        let ratio: CGFloat
+        let wasLeftChild: Bool
+    }
+    private var savedRatios: [CGWindowID: SavedRatio] = [:]
+
     init(displayManager: DisplayManager) {
         self.displayManager = displayManager
     }
@@ -88,9 +98,35 @@ class TilingEngine {
     func removeWindowID(_ windowID: CGWindowID) {
         for (_, t) in trees {
             guard let w = t.allWindows.first(where: { $0.windowID == windowID }) else { continue }
+            saveRatioBeforeRemoval(window: w, in: t)
             t.remove(w)
             t.root.pruneEmptyNodes()
             return
+        }
+    }
+
+    /// Drop any saved ratio for `windowID`. Called alongside
+    /// `forgetMinimumSize` when a window is truly gone (app quit).
+    func forgetSavedRatio(windowID: CGWindowID) { savedRatios.removeValue(forKey: windowID) }
+
+    private func saveRatioBeforeRemoval(window: HyprWindow, in tree: BSPTree) {
+        guard let node = tree.root.find(window) else { return }
+        guard let parent = node.parent else { return }
+        guard parent.splitRatio != TilingConfig.defaultRatio || parent.userSetRatio else { return }
+        let isLeft = parent.left === node
+        savedRatios[window.windowID] = SavedRatio(ratio: parent.splitRatio, wasLeftChild: isLeft)
+    }
+
+    /// Restore saved ratios for windows present in the tree.
+    /// Called after insert + ratio reset so restored ratios are not wiped.
+    private func restoreSavedRatios(in tree: BSPTree) {
+        for window in tree.allWindows {
+            guard let saved = savedRatios.removeValue(forKey: window.windowID) else { continue }
+            guard let node = tree.root.find(window), let parent = node.parent else { continue }
+            let isLeft = parent.left === node
+            let ratio = (isLeft == saved.wasLeftChild) ? saved.ratio : (1.0 - saved.ratio)
+            parent.splitRatio = ratio
+            parent.userSetRatio = true
         }
     }
 
@@ -351,7 +387,10 @@ class TilingEngine {
         let currentIDs = Set(tileWindows.map { $0.windowID })
         let treeIDs = Set(treeWindows.map { $0.windowID })
 
-        for w in treeWindows where !currentIDs.contains(w.windowID) { t.remove(w) }
+        for w in treeWindows where !currentIDs.contains(w.windowID) {
+            saveRatioBeforeRemoval(window: w, in: t)
+            t.remove(w)
+        }
 
         t.root.pruneEmptyNodes()
         // no compact on removal — BSPNode.remove promotes the sibling with
@@ -392,6 +431,7 @@ class TilingEngine {
             t.root.clearUserSetRatios()
             t.root.resetSplitRatios()
         }
+        restoreSavedRatios(in: t)
         return TileMembershipResult(key: key, tree: t, rect: rect, insertedWindows: insertedWindows)
     }
 
@@ -482,7 +522,10 @@ class TilingEngine {
         let treeIDs = Set(treeWindows.map { $0.windowID })
 
         // membership diff: remove gone (sibling promotion keeps shape), insert new
-        for w in treeWindows where !currentIDs.contains(w.windowID) { t.remove(w) }
+        for w in treeWindows where !currentIDs.contains(w.windowID) {
+            saveRatioBeforeRemoval(window: w, in: t)
+            t.remove(w)
+        }
         t.root.pruneEmptyNodes()
         t.root.resetSplitRatios()
 
@@ -495,6 +538,7 @@ class TilingEngine {
         }
 
         t.root.resetSplitRatios()
+        restoreSavedRatios(in: t)
         let layouts = t.layout(in: rect, gap: gapSize, padding: outerPadding)
         let conflicts = applyLayout(layouts)
         if !conflicts.isEmpty {

--- a/HyprMacTests/RatioMemoryTests.swift
+++ b/HyprMacTests/RatioMemoryTests.swift
@@ -1,129 +1,152 @@
 import XCTest
-import Cocoa
 @testable import HyprMac
 
 final class RatioMemoryTests: XCTestCase {
 
-    private var displayManager: DisplayManager!
-    private var engine: TilingEngine!
-    private var screen: NSScreen!
-
-    override func setUpWithError() throws {
-        displayManager = DisplayManager()
-        engine = TilingEngine(displayManager: displayManager)
-        guard let main = NSScreen.main ?? NSScreen.screens.first else {
-            throw XCTSkip("no NSScreen available — test requires a display")
-        }
-        screen = main
+    private func insertAndApply(_ window: HyprWindow, into tree: BSPTree) {
+        tree.insert(window)
+        tree.root.applySavedRatios()
     }
 
-    // MARK: - save and restore round-trip
+    // MARK: - right child removed
 
-    func testRatioRestoredAfterRemoveAndReinsert() {
+    func testRemoveRightChildPreservesRatioOnReinsert() {
+        let tree = BSPTree()
         let a = makeWindow(id: 1)
         let b = makeWindow(id: 2)
-        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+        tree.insert(a)
+        tree.insert(b)
 
-        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
         tree.root.splitRatio = 0.7
         tree.root.userSetRatio = true
 
-        // remove window b — its ratio should be remembered
-        engine.removeWindowID(b.windowID)
-        XCTAssertEqual(tree.allWindows.count, 1)
+        tree.remove(b)
+        XCTAssertEqual(tree.root.window, a)
 
-        // re-add b — ratio should restore
-        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
-        let tree2 = engine.existingTree(forWorkspace: 1, screen: screen)!
-        XCTAssertEqual(tree2.root.splitRatio, 0.7, accuracy: 0.001,
-                       "saved ratio should be restored after re-insert")
-        XCTAssertTrue(tree2.root.userSetRatio)
+        insertAndApply(makeWindow(id: 3), into: tree)
+
+        XCTAssertEqual(tree.root.splitRatio, 0.7, accuracy: 0.001,
+                       "ratio should survive right-child removal + reinsert")
+        XCTAssertTrue(tree.root.userSetRatio)
+    }
+
+    // MARK: - left child removed (exercises 1.0-ratio flip)
+
+    func testRemoveLeftChildPreservesRatioOnReinsert() {
+        let tree = BSPTree()
+        let a = makeWindow(id: 1)
+        let b = makeWindow(id: 2)
+        tree.insert(a)
+        tree.insert(b)
+
+        tree.root.splitRatio = 0.7
+        tree.root.userSetRatio = true
+
+        tree.remove(a)
+        XCTAssertEqual(tree.root.window, b)
+
+        insertAndApply(makeWindow(id: 3), into: tree)
+
+        XCTAssertEqual(tree.root.splitRatio, 0.7, accuracy: 0.001,
+                       "left-child removal: new window takes the left slot, ratio preserved")
+        XCTAssertTrue(tree.root.userSetRatio)
     }
 
     // MARK: - default ratio is not saved
 
     func testDefaultRatioNotSaved() {
+        let tree = BSPTree()
         let a = makeWindow(id: 1)
         let b = makeWindow(id: 2)
-        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+        tree.insert(a)
+        tree.insert(b)
 
-        // leave ratio at default 0.5, userSetRatio = false
-        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
-        XCTAssertEqual(tree.root.splitRatio, 0.5, accuracy: 0.001)
+        tree.remove(b)
+        insertAndApply(makeWindow(id: 3), into: tree)
+
+        XCTAssertEqual(tree.root.splitRatio, TilingConfig.defaultRatio, accuracy: 0.001,
+                       "default 50/50 ratio should not be saved")
         XCTAssertFalse(tree.root.userSetRatio)
-
-        engine.removeWindowID(b.windowID)
-        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
-
-        let tree2 = engine.existingTree(forWorkspace: 1, screen: screen)!
-        // ratio should stay at default — nothing was saved
-        XCTAssertEqual(tree2.root.splitRatio, 0.5, accuracy: 0.001)
     }
 
-    // MARK: - forgetSavedRatio
+    // MARK: - memory consumed after apply
 
-    func testForgetSavedRatioPreventsRestore() {
+    func testSavedRatioClearedAfterApply() {
+        let tree = BSPTree()
         let a = makeWindow(id: 1)
         let b = makeWindow(id: 2)
-        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
-
-        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
+        tree.insert(a)
+        tree.insert(b)
         tree.root.splitRatio = 0.7
         tree.root.userSetRatio = true
 
-        engine.removeWindowID(b.windowID)
-        engine.forgetSavedRatio(windowID: b.windowID)
+        tree.remove(b)
+        insertAndApply(makeWindow(id: 3), into: tree)
 
-        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
-        let tree2 = engine.existingTree(forWorkspace: 1, screen: screen)!
-        XCTAssertEqual(tree2.root.splitRatio, 0.5, accuracy: 0.001,
-                       "forgotten ratio should not restore — should reset to default")
+        XCTAssertNil(tree.root.savedSplitRatio,
+                     "saved ratio should be consumed on apply, not linger")
     }
 
-    // MARK: - ratio re-saved on each removal
+    // MARK: - single window removal (root)
 
-    func testRatioReSavedOnSubsequentRemoval() {
+    func testRemoveOnlyWindowDoesNotCrash() {
+        let tree = BSPTree()
+        let a = makeWindow(id: 1)
+        tree.insert(a)
+        tree.root.splitRatio = 0.7
+        tree.root.userSetRatio = true
+
+        tree.remove(a)
+        XCTAssertTrue(tree.root.isEmpty)
+
+        insertAndApply(makeWindow(id: 2), into: tree)
+        XCTAssertEqual(tree.root.splitRatio, TilingConfig.defaultRatio, accuracy: 0.001)
+    }
+
+    // MARK: - deeper tree
+
+    func testRatioMemoryWorksAtDepth() {
+        let tree = BSPTree()
         let a = makeWindow(id: 1)
         let b = makeWindow(id: 2)
-        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+        let c = makeWindow(id: 3)
+        tree.insert(a)
+        tree.insert(b)
+        tree.insert(c)
 
-        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
+        let sub = tree.root.right!
+        sub.splitRatio = 0.6
+        sub.userSetRatio = true
+
+        tree.remove(c)
+        XCTAssertEqual(tree.root.right?.window, b)
+
+        let d = makeWindow(id: 4)
+        tree.root.right?.insert(d)
+        tree.root.applySavedRatios()
+
+        XCTAssertEqual(tree.root.right?.splitRatio ?? 0, 0.6, accuracy: 0.001,
+                       "ratio at depth should survive removal + reinsert")
+    }
+
+    // MARK: - ratio survives multiple cycles
+
+    func testRatioSurvivesMultipleCycles() {
+        let tree = BSPTree()
+        let a = makeWindow(id: 1)
+        let b = makeWindow(id: 2)
+        tree.insert(a)
+        tree.insert(b)
         tree.root.splitRatio = 0.65
         tree.root.userSetRatio = true
 
-        engine.removeWindowID(b.windowID)
+        tree.remove(b)
+        insertAndApply(makeWindow(id: 3), into: tree)
+        XCTAssertEqual(tree.root.splitRatio, 0.65, accuracy: 0.001)
 
-        // first re-insert restores 0.65
-        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
-        let tree2 = engine.existingTree(forWorkspace: 1, screen: screen)!
-        XCTAssertEqual(tree2.root.splitRatio, 0.65, accuracy: 0.001)
-
-        // remove again — the restored ratio (0.65, userSetRatio=true) is
-        // re-saved, so the next insert also gets 0.65
-        engine.removeWindowID(b.windowID)
-        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
-        let tree3 = engine.existingTree(forWorkspace: 1, screen: screen)!
-        XCTAssertEqual(tree3.root.splitRatio, 0.65, accuracy: 0.001,
-                       "ratio should be re-saved on each removal — survives multiple cycles")
-    }
-
-    // MARK: - userSetRatio at default is still saved
-
-    func testUserSetRatioAtDefaultIsSaved() {
-        let a = makeWindow(id: 1)
-        let b = makeWindow(id: 2)
-        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
-
-        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
-        // user manually set to 0.5 (same as default but flagged)
-        tree.root.splitRatio = 0.5
-        tree.root.userSetRatio = true
-
-        engine.removeWindowID(b.windowID)
-        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
-
-        let tree2 = engine.existingTree(forWorkspace: 1, screen: screen)!
-        XCTAssertTrue(tree2.root.userSetRatio,
-                      "userSetRatio flag should survive save/restore even at default ratio")
+        tree.remove(tree.root.right!.window!)
+        insertAndApply(makeWindow(id: 4), into: tree)
+        XCTAssertEqual(tree.root.splitRatio, 0.65, accuracy: 0.001,
+                       "ratio should survive multiple remove/reinsert cycles")
     }
 }

--- a/HyprMacTests/RatioMemoryTests.swift
+++ b/HyprMacTests/RatioMemoryTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+import Cocoa
+@testable import HyprMac
+
+final class RatioMemoryTests: XCTestCase {
+
+    private var displayManager: DisplayManager!
+    private var engine: TilingEngine!
+    private var screen: NSScreen!
+
+    override func setUpWithError() throws {
+        displayManager = DisplayManager()
+        engine = TilingEngine(displayManager: displayManager)
+        guard let main = NSScreen.main ?? NSScreen.screens.first else {
+            throw XCTSkip("no NSScreen available — test requires a display")
+        }
+        screen = main
+    }
+
+    // MARK: - save and restore round-trip
+
+    func testRatioRestoredAfterRemoveAndReinsert() {
+        let a = makeWindow(id: 1)
+        let b = makeWindow(id: 2)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+
+        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
+        tree.root.splitRatio = 0.7
+        tree.root.userSetRatio = true
+
+        // remove window b — its ratio should be remembered
+        engine.removeWindowID(b.windowID)
+        XCTAssertEqual(tree.allWindows.count, 1)
+
+        // re-add b — ratio should restore
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+        let tree2 = engine.existingTree(forWorkspace: 1, screen: screen)!
+        XCTAssertEqual(tree2.root.splitRatio, 0.7, accuracy: 0.001,
+                       "saved ratio should be restored after re-insert")
+        XCTAssertTrue(tree2.root.userSetRatio)
+    }
+
+    // MARK: - default ratio is not saved
+
+    func testDefaultRatioNotSaved() {
+        let a = makeWindow(id: 1)
+        let b = makeWindow(id: 2)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+
+        // leave ratio at default 0.5, userSetRatio = false
+        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
+        XCTAssertEqual(tree.root.splitRatio, 0.5, accuracy: 0.001)
+        XCTAssertFalse(tree.root.userSetRatio)
+
+        engine.removeWindowID(b.windowID)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+
+        let tree2 = engine.existingTree(forWorkspace: 1, screen: screen)!
+        // ratio should stay at default — nothing was saved
+        XCTAssertEqual(tree2.root.splitRatio, 0.5, accuracy: 0.001)
+    }
+
+    // MARK: - forgetSavedRatio
+
+    func testForgetSavedRatioPreventsRestore() {
+        let a = makeWindow(id: 1)
+        let b = makeWindow(id: 2)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+
+        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
+        tree.root.splitRatio = 0.7
+        tree.root.userSetRatio = true
+
+        engine.removeWindowID(b.windowID)
+        engine.forgetSavedRatio(windowID: b.windowID)
+
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+        let tree2 = engine.existingTree(forWorkspace: 1, screen: screen)!
+        XCTAssertEqual(tree2.root.splitRatio, 0.5, accuracy: 0.001,
+                       "forgotten ratio should not restore — should reset to default")
+    }
+
+    // MARK: - ratio re-saved on each removal
+
+    func testRatioReSavedOnSubsequentRemoval() {
+        let a = makeWindow(id: 1)
+        let b = makeWindow(id: 2)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+
+        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
+        tree.root.splitRatio = 0.65
+        tree.root.userSetRatio = true
+
+        engine.removeWindowID(b.windowID)
+
+        // first re-insert restores 0.65
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+        let tree2 = engine.existingTree(forWorkspace: 1, screen: screen)!
+        XCTAssertEqual(tree2.root.splitRatio, 0.65, accuracy: 0.001)
+
+        // remove again — the restored ratio (0.65, userSetRatio=true) is
+        // re-saved, so the next insert also gets 0.65
+        engine.removeWindowID(b.windowID)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+        let tree3 = engine.existingTree(forWorkspace: 1, screen: screen)!
+        XCTAssertEqual(tree3.root.splitRatio, 0.65, accuracy: 0.001,
+                       "ratio should be re-saved on each removal — survives multiple cycles")
+    }
+
+    // MARK: - userSetRatio at default is still saved
+
+    func testUserSetRatioAtDefaultIsSaved() {
+        let a = makeWindow(id: 1)
+        let b = makeWindow(id: 2)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+
+        let tree = engine.existingTree(forWorkspace: 1, screen: screen)!
+        // user manually set to 0.5 (same as default but flagged)
+        tree.root.splitRatio = 0.5
+        tree.root.userSetRatio = true
+
+        engine.removeWindowID(b.windowID)
+        _ = engine.prepareTileLayout([a, b], onWorkspace: 1, screen: screen)
+
+        let tree2 = engine.existingTree(forWorkspace: 1, screen: screen)!
+        XCTAssertTrue(tree2.root.userSetRatio,
+                      "userSetRatio flag should survive save/restore even at default ratio")
+    }
+}


### PR DESCRIPTION
## Summary

Remembers per-window BSP split ratios across hide/show cycles (e.g. macOS native tab switches). Without this, switching tabs resets all splits to 50:50 because the hidden window is removed from the tree and the newly visible one is re-inserted at the default ratio.

### Problem

Apps that use macOS native tabs (Ghostty, Chrome, etc.) create separate windows per tab. When switching tabs, the old window hides and the new one appears — HyprMac removes the hidden window from the BSP tree and re-inserts the visible one at the default 0.5 ratio, losing any user-configured split.

### Solution

Track `[CGWindowID: SavedRatio]` in `TilingEngine`. Before a window is removed from the tree, its parent's `splitRatio` and child position (left/right) are saved. When the window re-enters the tree, the saved ratio is restored — adjusted for child-position changes so the window keeps its proportional size regardless of BSP insertion order.

### Changes

- **`TilingEngine.swift`** (+46): `SavedRatio` struct, `savedRatios` dictionary, `saveRatioBeforeRemoval` (captures ratio + child position before tree removal), `restoreSavedRatios` (applies saved ratios after insert, compensating for left↔right swaps), `forgetSavedRatio` (cleanup for truly-closed windows). Save calls in both `updateTreeMembership` and `removeWindowID`.
- **`WindowManager.swift`** (+1): `forgetSavedRatio` call in `applyForgottenIDExternalCleanup` so closed windows don't leak entries.

### Design decisions

- **Always on** — no config toggle. Resetting to 50:50 on every tab switch is never the desired behaviour, so this is a pure quality-of-life fix.
- **Only saves non-default ratios** — avoids polluting the cache with 50:50 entries that would be no-ops.
- **In-memory only** — ratios are not persisted to disk. Cleaned up when the window is truly closed (app quit/termination).
- **Child-position compensation** — if a window was the left child at 67% before hiding but re-inserts as the right child, the ratio is flipped to 33% so it occupies the same proportional space.

### Testing

Tested on macOS Tahoe (26.5) with Ghostty native tabs. Resize a split, switch tabs, switch back — ratio is preserved. Works with the keyboard resize feature (#12) when both are applied.