### PR TITLE
Add configurable window corner radius

### DIFF
--- a/HyprMac/Core/FocusBorder.swift
+++ b/HyprMac/Core/FocusBorder.swift
@@ -191,6 +191,22 @@ class FocusBorder {
         trackedWindowFrame = rect
     }
 
+    /// Re-stamp the configured curvature without replaying show animations.
+    func refreshCornerRadius() {
+        mainThreadOnly()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        if let windowID = trackedWindowID, let layer = glowView?.layer {
+            layer.cornerRadius = WindowCornerRadius.resolve(for: windowID)
+                + Tuning.activeBorderWidth / 2
+        }
+        for (windowID, border) in floatingPanels {
+            border.glowView.layer?.cornerRadius = WindowCornerRadius.resolve(for: windowID)
+                + Tuning.floatingBorderWidth / 2
+        }
+        CATransaction.commit()
+    }
+
     /// Sync the floating-border panels to `frames`. Creates panels for
     /// new ids, repositions existing ones, and orders out any panel
     /// whose id is not present in the input — so a single call brings

--- a/HyprMac/Core/FocusBrackets.swift
+++ b/HyprMac/Core/FocusBrackets.swift
@@ -115,6 +115,13 @@ class FocusBrackets {
         trackedFrame = rect
     }
 
+    /// Rebuild visible bracket paths after the configured radius changes.
+    func refreshCornerRadius() {
+        mainThreadOnly()
+        guard isVisible else { return }
+        stampCornerPaths()
+    }
+
     /// Fade out and order out. Cheap to call repeatedly — no-op when
     /// already hidden.
     func hide() {

--- a/HyprMac/Core/WindowCornerRadius.swift
+++ b/HyprMac/Core/WindowCornerRadius.swift
@@ -3,22 +3,18 @@
 // macOS apps render their corners themselves and there's no public AX
 // attribute to read the actual radius. Per-bundle override tables and
 // dynamic probing both produced inconsistent results across apps, so
-// we pick one global radius keyed only on the macOS version. Same
-// value used by FocusBorder and DimmingOverlay so they stay in sync.
+// we use one user-configurable global radius. Its default remains keyed
+// to the macOS version so existing installations keep their appearance.
+// The same value drives all focus chrome so its curves stay in sync.
 
 import Cocoa
 
 enum WindowCornerRadius {
 
-    // Tahoe (macOS 26) renders noticeably rounder corners than Sequoia
-    // (15). 16pt is Tahoe's default window corner radius; 10pt matches
-    // Sequoia and earlier.
-    static let global: CGFloat = {
-        if ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26 {
-            return 16
-        }
-        return 10
-    }()
+    /// Current user-selected radius. `UserConfigDefaults` preserves the
+    /// previous 16pt Tahoe / 10pt earlier-version behavior when the saved
+    /// config predates this setting.
+    static var global: CGFloat { UserConfig.shared.windowCornerRadius }
 
     /// Resolve the radius for `wid`. Currently returns the same global
     /// value for every window — the API shape is preserved so the

--- a/HyprMac/Core/WindowManager.swift
+++ b/HyprMac/Core/WindowManager.swift
@@ -598,6 +598,16 @@ class WindowManager {
                 self.dimmingOverlay.fadeDurationSec = duration
             }.store(in: &configObservers)
 
+        config.$windowCornerRadius
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.focusBorder.refreshCornerRadius()
+                self.focusBrackets.refreshCornerRadius()
+                self.refreshDimming()
+            }.store(in: &configObservers)
+
         config.$showFocusBorder
             .dropFirst()
             .removeDuplicates()

--- a/HyprMac/Models/UserConfig.swift
+++ b/HyprMac/Models/UserConfig.swift
@@ -78,6 +78,10 @@ class UserConfig: ObservableObject {
     @Published var chromeFadeDurationSec: Double {
         didSet { if !isReloading { save() } }
     }
+    // corner curvature shared by focus borders, brackets, and dim cut-outs
+    @Published var windowCornerRadius: CGFloat {
+        didSet { if !isReloading { save() } }
+    }
     // windows sent to the scratchpad tile into the layer by default;
     // ones that don't fit stay floating members either way
     @Published var scratchpadTileByDefault: Bool {
@@ -141,6 +145,7 @@ class UserConfig: ObservableObject {
             self.dimInactiveWindows = saved.dimInactiveWindows ?? UserConfigDefaults.dimInactiveWindows
             self.dimIntensity = saved.dimIntensity ?? UserConfigDefaults.dimIntensity
             self.chromeFadeDurationSec = saved.chromeFadeDurationSec ?? UserConfigDefaults.chromeFadeDurationSec
+            self.windowCornerRadius = saved.windowCornerRadius ?? UserConfigDefaults.windowCornerRadius
             self.scratchpadTileByDefault = saved.scratchpadTileByDefault ?? UserConfigDefaults.scratchpadTileByDefault
             self.scratchpadRegionInset = saved.scratchpadRegionInset ?? UserConfigDefaults.scratchpadRegionInset
         } else {
@@ -159,6 +164,7 @@ class UserConfig: ObservableObject {
             self.dimInactiveWindows = UserConfigDefaults.dimInactiveWindows
             self.dimIntensity = UserConfigDefaults.dimIntensity
             self.chromeFadeDurationSec = UserConfigDefaults.chromeFadeDurationSec
+            self.windowCornerRadius = UserConfigDefaults.windowCornerRadius
             self.scratchpadTileByDefault = UserConfigDefaults.scratchpadTileByDefault
             self.scratchpadRegionInset = UserConfigDefaults.scratchpadRegionInset
         }
@@ -236,6 +242,7 @@ class UserConfig: ObservableObject {
             dimIntensity: dimIntensity,
             mouseHoverPollHz: mouseHoverPollHz,
             chromeFadeDurationSec: chromeFadeDurationSec,
+            windowCornerRadius: windowCornerRadius,
             scratchpadTileByDefault: scratchpadTileByDefault,
             scratchpadRegionInset: scratchpadRegionInset)
     }
@@ -258,6 +265,7 @@ class UserConfig: ObservableObject {
         dimInactiveWindows = UserConfigDefaults.dimInactiveWindows
         dimIntensity = UserConfigDefaults.dimIntensity
         chromeFadeDurationSec = UserConfigDefaults.chromeFadeDurationSec
+        windowCornerRadius = UserConfigDefaults.windowCornerRadius
         scratchpadTileByDefault = UserConfigDefaults.scratchpadTileByDefault
         scratchpadRegionInset = UserConfigDefaults.scratchpadRegionInset
     }
@@ -292,6 +300,7 @@ class UserConfig: ObservableObject {
         dimInactiveWindows = saved.dimInactiveWindows ?? false
         dimIntensity = saved.dimIntensity ?? 0.2
         chromeFadeDurationSec = saved.chromeFadeDurationSec ?? UserConfigDefaults.chromeFadeDurationSec
+        windowCornerRadius = saved.windowCornerRadius ?? UserConfigDefaults.windowCornerRadius
         scratchpadTileByDefault = saved.scratchpadTileByDefault ?? UserConfigDefaults.scratchpadTileByDefault
         scratchpadRegionInset = saved.scratchpadRegionInset ?? UserConfigDefaults.scratchpadRegionInset
 
@@ -330,6 +339,7 @@ extension SavedConfig {
             dimIntensity: UserConfigDefaults.dimIntensity,
             mouseHoverPollHz: UserConfigDefaults.mouseHoverPollHz,
             chromeFadeDurationSec: UserConfigDefaults.chromeFadeDurationSec,
+            windowCornerRadius: UserConfigDefaults.windowCornerRadius,
             scratchpadTileByDefault: UserConfigDefaults.scratchpadTileByDefault,
             scratchpadRegionInset: UserConfigDefaults.scratchpadRegionInset)
     }

--- a/HyprMac/Models/UserConfigDefaults.swift
+++ b/HyprMac/Models/UserConfigDefaults.swift
@@ -27,6 +27,13 @@ enum UserConfigDefaults {
     // global enable/disable). settle and shake on FocusBorder stay at
     // their own constants.
     static let chromeFadeDurationSec: Double = 0.22
+    // Match the hard-coded radius used before this became configurable:
+    // Tahoe windows are rounder than windows on Sequoia and earlier.
+    static func windowCornerRadius(forOSMajorVersion majorVersion: Int) -> CGFloat {
+        majorVersion >= 26 ? 16 : 10
+    }
+    static let windowCornerRadius: CGFloat = windowCornerRadius(
+        forOSMajorVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion)
     // windows sent to the scratchpad tile into the layer instead of
     // floating. off preserves the original floating-first behavior.
     static let scratchpadTileByDefault: Bool = false

--- a/HyprMac/Persistence/ConfigStore.swift
+++ b/HyprMac/Persistence/ConfigStore.swift
@@ -230,6 +230,7 @@ struct SavedConfig: Codable {
     let dimIntensity: Double?
     let mouseHoverPollHz: Int?
     let chromeFadeDurationSec: Double?
+    let windowCornerRadius: CGFloat?
     let scratchpadTileByDefault: Bool?
     let scratchpadRegionInset: CGFloat?
 }

--- a/HyprMac/Settings/TilingSettingsView.swift
+++ b/HyprMac/Settings/TilingSettingsView.swift
@@ -119,6 +119,17 @@ struct TilingSettingsView: View {
                     .labelsHidden()
             }
 
+            HyprRow("Corner radius", icon: "rectangle.roundedtop",
+                    subtitle: "Matches focus borders, brackets, and dim cut-outs.",
+                    divider: true) {
+                HStack(spacing: HyprSpacing.sm) {
+                    Slider(value: $config.windowCornerRadius, in: 0...32, step: 1)
+                        .frame(width: 180)
+                    HyprChip("\(Int(config.windowCornerRadius)) px")
+                        .frame(width: 56, alignment: .trailing)
+                }
+            }
+
             HyprRow("Dim inactive windows", icon: "moon",
                     divider: config.dimInactiveWindows) {
                 Toggle("", isOn: $config.dimInactiveWindows)

--- a/HyprMacTests/ConfigMigrationTests.swift
+++ b/HyprMacTests/ConfigMigrationTests.swift
@@ -63,6 +63,7 @@ final class ConfigMigrationTests: XCTestCase {
         XCTAssertNil(saved.excludedBundleIDs)
         XCTAssertNil(saved.dimIntensity)
         XCTAssertNil(saved.maxSplitsPerMonitor)
+        XCTAssertNil(saved.windowCornerRadius)
         XCTAssertNil(saved.scratchpadTileByDefault)
         XCTAssertNil(saved.scratchpadRegionInset)
     }
@@ -80,6 +81,7 @@ final class ConfigMigrationTests: XCTestCase {
             focusBorderColorHex: "007AFF", floatingBorderColorHex: nil,
             dimInactiveWindows: true, dimIntensity: 0.5,
             mouseHoverPollHz: nil, chromeFadeDurationSec: nil,
+            windowCornerRadius: 13,
             scratchpadTileByDefault: true, scratchpadRegionInset: 0.03)
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(SavedConfig.self, from: data)
@@ -89,6 +91,7 @@ final class ConfigMigrationTests: XCTestCase {
         XCTAssertEqual(decoded.excludedBundleIDs, ["com.apple.FaceTime"])
         XCTAssertEqual(decoded.dimIntensity, 0.5)
         XCTAssertEqual(decoded.focusBorderColorHex, "007AFF")
+        XCTAssertEqual(decoded.windowCornerRadius, 13)
         XCTAssertEqual(decoded.scratchpadTileByDefault, true)
         XCTAssertEqual(decoded.scratchpadRegionInset, 0.03)
     }
@@ -107,6 +110,7 @@ final class ConfigMigrationTests: XCTestCase {
             showFocusBorder: nil, focusBorderColorHex: nil,
             floatingBorderColorHex: nil, dimInactiveWindows: nil, dimIntensity: nil,
             mouseHoverPollHz: nil, chromeFadeDurationSec: nil,
+            windowCornerRadius: nil,
             scratchpadTileByDefault: nil, scratchpadRegionInset: nil)
         let r = ConfigMigration.resolveMonitorConfig(local: local, embedded: embedded)
         XCTAssertEqual(r.maxSplits, ["Display A": 4])
@@ -125,6 +129,7 @@ final class ConfigMigrationTests: XCTestCase {
             showFocusBorder: nil, focusBorderColorHex: nil,
             floatingBorderColorHex: nil, dimInactiveWindows: nil, dimIntensity: nil,
             mouseHoverPollHz: nil, chromeFadeDurationSec: nil,
+            windowCornerRadius: nil,
             scratchpadTileByDefault: nil, scratchpadRegionInset: nil)
         let r = ConfigMigration.resolveMonitorConfig(local: nil, embedded: embedded)
         XCTAssertEqual(r.maxSplits, ["DELL U2723QE": 2])
@@ -149,6 +154,7 @@ final class ConfigMigrationTests: XCTestCase {
             showFocusBorder: nil, focusBorderColorHex: nil,
             floatingBorderColorHex: nil, dimInactiveWindows: nil, dimIntensity: nil,
             mouseHoverPollHz: nil, chromeFadeDurationSec: nil,
+            windowCornerRadius: nil,
             scratchpadTileByDefault: nil, scratchpadRegionInset: nil)
         let r = ConfigMigration.resolveMonitorConfig(local: nil, embedded: embedded)
         XCTAssertFalse(r.needsLocalWrite,
@@ -160,6 +166,11 @@ final class ConfigMigrationTests: XCTestCase {
     func testFromHexValidSixDigit() {
         XCTAssertNotNil(NSColor.fromHex("007AFF"))
         XCTAssertNotNil(NSColor.fromHex("#007AFF"))  // strip leading hash
+    }
+
+    func testWindowCornerRadiusDefaultsPreservePreviousBehavior() {
+        XCTAssertEqual(UserConfigDefaults.windowCornerRadius(forOSMajorVersion: 15), 10)
+        XCTAssertEqual(UserConfigDefaults.windowCornerRadius(forOSMajorVersion: 26), 16)
     }
 
     func testFromHexEmptyReturnsNil() {


### PR DESCRIPTION
# Configurable window corner radius

## Summary

- add a persisted `windowCornerRadius` setting with a 0–32 px slider in Settings → Tiling → Focus Chrome
- preserve the previous default behavior (16 px on macOS 26+, 10 px on earlier versions) for existing configs
- apply changes live to focus borders, floating borders, focus brackets, and dim-overlay cut-outs
- add config decoding, round-trip, and default-behavior coverage

## Tests

- full application Swift typecheck passed
- focused config compatibility and round-trip smoke tests passed
- optimized arm64 app build passed ad-hoc signature verification and launched successfully on macOS 26.6.2 with Accessibility/window-management startup confirmed

`xcodebuild test` was not available locally because the machine only has Xcode Command Line Tools. The XCTest cases are included for upstream CI.
