### PR TITLE
Fix corner radius defaults and error refresh

### DIFF
--- a/HyprMac/Core/FocusBorder.swift
+++ b/HyprMac/Core/FocusBorder.swift
@@ -76,6 +76,11 @@ class FocusBorder {
         static let errorFillAlpha: CGFloat = 0.12
     }
 
+    // The settled border keeps the active panel geometry, while an error
+    // flash uses its wider stroke. Refreshes must preserve whichever
+    // expansion was used when the focused border was last stamped.
+    private var focusedCornerRadiusExpansion = Tuning.activeBorderWidth / 2
+
     // resolved from config — call updateColor() when config changes
     var accentCGColor: CGColor = NSColor.controlAccentColor.cgColor
 
@@ -135,6 +140,7 @@ class FocusBorder {
         let shouldFadeIn = isFreshAppearance || isWindowSwitch
 
         let expansion = Tuning.activeBorderWidth / 2
+        focusedCornerRadiusExpansion = expansion
         let nsRect = panelRect(for: rect, expansion: expansion)
         let windowRadius = WindowCornerRadius.resolve(for: windowID)
 
@@ -198,13 +204,18 @@ class FocusBorder {
         CATransaction.setDisableActions(true)
         if let windowID = trackedWindowID, let layer = glowView?.layer {
             layer.cornerRadius = WindowCornerRadius.resolve(for: windowID)
-                + Tuning.activeBorderWidth / 2
+                + focusedCornerRadiusExpansion
         }
         for (windowID, border) in floatingPanels {
             border.glowView.layer?.cornerRadius = WindowCornerRadius.resolve(for: windowID)
                 + Tuning.floatingBorderWidth / 2
         }
         CATransaction.commit()
+    }
+
+    /// Synchronous style snapshot used by regression tests and diagnostics.
+    func currentFocusedBorderCornerRadius() -> CGFloat? {
+        glowView?.layer?.cornerRadius
     }
 
     /// Sync the floating-border panels to `frames`. Creates panels for
@@ -339,6 +350,7 @@ class FocusBorder {
         shakeTimer?.cancel()
 
         let expansion = Tuning.errorBorderWidth / 2
+        focusedCornerRadiusExpansion = expansion
         let nsRect = panelRect(for: rect, expansion: expansion)
         let windowRadius = WindowCornerRadius.resolve(for: windowID)
         let p: NSPanel

--- a/HyprMac/Core/WindowCornerRadius.swift
+++ b/HyprMac/Core/WindowCornerRadius.swift
@@ -11,9 +11,8 @@ import Cocoa
 
 enum WindowCornerRadius {
 
-    /// Current user-selected radius. `UserConfigDefaults` preserves the
-    /// previous 16pt Tahoe / 10pt earlier-version behavior when the saved
-    /// config predates this setting.
+    /// Current effective radius: an explicit user override, or the
+    /// OS-version-dependent default when no override is persisted.
     static var global: CGFloat { UserConfig.shared.windowCornerRadius }
 
     /// Resolve the radius for `wid`. Currently returns the same global

--- a/HyprMac/Core/WindowManager.swift
+++ b/HyprMac/Core/WindowManager.swift
@@ -598,7 +598,7 @@ class WindowManager {
                 self.dimmingOverlay.fadeDurationSec = duration
             }.store(in: &configObservers)
 
-        config.$windowCornerRadius
+        config.$windowCornerRadiusOverride
             .dropFirst()
             .removeDuplicates()
             .sink { [weak self] _ in

--- a/HyprMac/Models/UserConfig.swift
+++ b/HyprMac/Models/UserConfig.swift
@@ -78,9 +78,13 @@ class UserConfig: ObservableObject {
     @Published var chromeFadeDurationSec: Double {
         didSet { if !isReloading { save() } }
     }
-    // corner curvature shared by focus borders, brackets, and dim cut-outs
-    @Published var windowCornerRadius: CGFloat {
+    // nil follows the OS-version-dependent default; a value is an explicit
+    // user override shared by focus borders, brackets, and dim cut-outs
+    @Published var windowCornerRadiusOverride: CGFloat? {
         didSet { if !isReloading { save() } }
+    }
+    var windowCornerRadius: CGFloat {
+        windowCornerRadiusOverride ?? UserConfigDefaults.windowCornerRadius
     }
     // windows sent to the scratchpad tile into the layer by default;
     // ones that don't fit stay floating members either way
@@ -145,7 +149,7 @@ class UserConfig: ObservableObject {
             self.dimInactiveWindows = saved.dimInactiveWindows ?? UserConfigDefaults.dimInactiveWindows
             self.dimIntensity = saved.dimIntensity ?? UserConfigDefaults.dimIntensity
             self.chromeFadeDurationSec = saved.chromeFadeDurationSec ?? UserConfigDefaults.chromeFadeDurationSec
-            self.windowCornerRadius = saved.windowCornerRadius ?? UserConfigDefaults.windowCornerRadius
+            self.windowCornerRadiusOverride = saved.windowCornerRadius
             self.scratchpadTileByDefault = saved.scratchpadTileByDefault ?? UserConfigDefaults.scratchpadTileByDefault
             self.scratchpadRegionInset = saved.scratchpadRegionInset ?? UserConfigDefaults.scratchpadRegionInset
         } else {
@@ -164,7 +168,7 @@ class UserConfig: ObservableObject {
             self.dimInactiveWindows = UserConfigDefaults.dimInactiveWindows
             self.dimIntensity = UserConfigDefaults.dimIntensity
             self.chromeFadeDurationSec = UserConfigDefaults.chromeFadeDurationSec
-            self.windowCornerRadius = UserConfigDefaults.windowCornerRadius
+            self.windowCornerRadiusOverride = nil
             self.scratchpadTileByDefault = UserConfigDefaults.scratchpadTileByDefault
             self.scratchpadRegionInset = UserConfigDefaults.scratchpadRegionInset
         }
@@ -242,7 +246,7 @@ class UserConfig: ObservableObject {
             dimIntensity: dimIntensity,
             mouseHoverPollHz: mouseHoverPollHz,
             chromeFadeDurationSec: chromeFadeDurationSec,
-            windowCornerRadius: windowCornerRadius,
+            windowCornerRadius: windowCornerRadiusOverride,
             scratchpadTileByDefault: scratchpadTileByDefault,
             scratchpadRegionInset: scratchpadRegionInset)
     }
@@ -265,7 +269,7 @@ class UserConfig: ObservableObject {
         dimInactiveWindows = UserConfigDefaults.dimInactiveWindows
         dimIntensity = UserConfigDefaults.dimIntensity
         chromeFadeDurationSec = UserConfigDefaults.chromeFadeDurationSec
-        windowCornerRadius = UserConfigDefaults.windowCornerRadius
+        windowCornerRadiusOverride = nil
         scratchpadTileByDefault = UserConfigDefaults.scratchpadTileByDefault
         scratchpadRegionInset = UserConfigDefaults.scratchpadRegionInset
     }
@@ -300,7 +304,7 @@ class UserConfig: ObservableObject {
         dimInactiveWindows = saved.dimInactiveWindows ?? false
         dimIntensity = saved.dimIntensity ?? 0.2
         chromeFadeDurationSec = saved.chromeFadeDurationSec ?? UserConfigDefaults.chromeFadeDurationSec
-        windowCornerRadius = saved.windowCornerRadius ?? UserConfigDefaults.windowCornerRadius
+        windowCornerRadiusOverride = saved.windowCornerRadius
         scratchpadTileByDefault = saved.scratchpadTileByDefault ?? UserConfigDefaults.scratchpadTileByDefault
         scratchpadRegionInset = saved.scratchpadRegionInset ?? UserConfigDefaults.scratchpadRegionInset
 
@@ -339,7 +343,7 @@ extension SavedConfig {
             dimIntensity: UserConfigDefaults.dimIntensity,
             mouseHoverPollHz: UserConfigDefaults.mouseHoverPollHz,
             chromeFadeDurationSec: UserConfigDefaults.chromeFadeDurationSec,
-            windowCornerRadius: UserConfigDefaults.windowCornerRadius,
+            windowCornerRadius: nil,
             scratchpadTileByDefault: UserConfigDefaults.scratchpadTileByDefault,
             scratchpadRegionInset: UserConfigDefaults.scratchpadRegionInset)
     }

--- a/HyprMac/Models/UserConfigDefaults.swift
+++ b/HyprMac/Models/UserConfigDefaults.swift
@@ -32,7 +32,15 @@ enum UserConfigDefaults {
     static func windowCornerRadius(forOSMajorVersion majorVersion: Int) -> CGFloat {
         majorVersion >= 26 ? 16 : 10
     }
-    static let windowCornerRadius: CGFloat = windowCornerRadius(
+    // A missing override remains adaptive across macOS upgrades.
+    static func resolvedWindowCornerRadius(
+        override: CGFloat?,
+        forOSMajorVersion majorVersion: Int
+    ) -> CGFloat {
+        override ?? windowCornerRadius(forOSMajorVersion: majorVersion)
+    }
+    static let windowCornerRadius: CGFloat = resolvedWindowCornerRadius(
+        override: nil,
         forOSMajorVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion)
     // windows sent to the scratchpad tile into the layer instead of
     // floating. off preserves the original floating-first behavior.

--- a/HyprMac/Settings/TilingSettingsView.swift
+++ b/HyprMac/Settings/TilingSettingsView.swift
@@ -120,13 +120,21 @@ struct TilingSettingsView: View {
             }
 
             HyprRow("Corner radius", icon: "rectangle.roundedtop",
-                    subtitle: "Matches focus borders, brackets, and dim cut-outs.",
+                    subtitle: "Matches focus borders, brackets, and dim cut-outs. OS default adapts after macOS upgrades.",
                     divider: true) {
                 HStack(spacing: HyprSpacing.sm) {
-                    Slider(value: $config.windowCornerRadius, in: 0...32, step: 1)
+                    Slider(value: Binding(
+                        get: { config.windowCornerRadius },
+                        set: { config.windowCornerRadiusOverride = $0 }
+                    ), in: 0...32, step: 1)
                         .frame(width: 180)
                     HyprChip("\(Int(config.windowCornerRadius)) px")
                         .frame(width: 56, alignment: .trailing)
+                    Button("OS default") {
+                        config.windowCornerRadiusOverride = nil
+                    }
+                    .controlSize(.small)
+                    .disabled(config.windowCornerRadiusOverride == nil)
                 }
             }
 

--- a/HyprMacTests/ConfigMigrationTests.swift
+++ b/HyprMacTests/ConfigMigrationTests.swift
@@ -10,6 +10,7 @@ import AppKit
 //   configs from hand-edited files or older releases must not crash)
 // - encoder omits the version field when nil, preserving the byte-equal
 //   contract for unchanged settings
+// - a nil corner-radius override stays omitted so OS defaults remain adaptive
 // - ConfigMigration.resolveMonitorConfig handles the local-only / migrated /
 //   embedded variants
 // - NSColor.fromHex returns nil + does not crash on malformed input
@@ -171,6 +172,29 @@ final class ConfigMigrationTests: XCTestCase {
     func testWindowCornerRadiusDefaultsPreservePreviousBehavior() {
         XCTAssertEqual(UserConfigDefaults.windowCornerRadius(forOSMajorVersion: 15), 10)
         XCTAssertEqual(UserConfigDefaults.windowCornerRadius(forOSMajorVersion: 26), 16)
+    }
+
+    func testUnsetWindowCornerRadiusTracksOSVersion() {
+        XCTAssertEqual(UserConfigDefaults.resolvedWindowCornerRadius(
+            override: nil, forOSMajorVersion: 15), 10)
+        XCTAssertEqual(UserConfigDefaults.resolvedWindowCornerRadius(
+            override: nil, forOSMajorVersion: 26), 16)
+    }
+
+    func testExplicitWindowCornerRadiusOverridesOSDefault() {
+        XCTAssertEqual(UserConfigDefaults.resolvedWindowCornerRadius(
+            override: 13, forOSMajorVersion: 15), 13)
+        XCTAssertEqual(UserConfigDefaults.resolvedWindowCornerRadius(
+            override: 13, forOSMajorVersion: 26), 13)
+    }
+
+    func testOSDefaultWindowCornerRadiusIsNotPersisted() throws {
+        let saved = SavedConfig.empty
+        XCTAssertNil(saved.windowCornerRadius)
+
+        let json = String(data: try JSONEncoder().encode(saved), encoding: .utf8)!
+        XCTAssertFalse(json.contains("\"windowCornerRadius\""),
+                       "OS-default mode must stay adaptive instead of pinning a resolved value: \(json)")
     }
 
     func testFromHexEmptyReturnsNil() {

--- a/HyprMacTests/FocusStateControllerTests.swift
+++ b/HyprMacTests/FocusStateControllerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Cocoa
 @testable import HyprMac
 
 // FocusStateControllerTests pin focus transition semantics and idempotence.
@@ -59,5 +60,24 @@ final class FocusStateControllerTests: XCTestCase {
         c.recordFocus(42, reason: "first")
         c.recordFocus(42, reason: "redundant")
         XCTAssertEqual(c.lastFocusedID, 42)
+    }
+}
+
+final class FocusBorderCornerRadiusTests: XCTestCase {
+
+    func testRefreshPreservesErrorBorderWidthExpansion() throws {
+        let border = FocusBorder()
+        border.primaryScreenHeight = 1080
+        defer { border.hide() }
+
+        let windowID: CGWindowID = 42
+        border.flashError(
+            around: CGRect(x: 100, y: 100, width: 400, height: 300),
+            windowID: windowID)
+        border.refreshCornerRadius()
+
+        let renderedRadius = try XCTUnwrap(border.currentFocusedBorderCornerRadius())
+        let expectedRadius = WindowCornerRadius.resolve(for: windowID) + 1.25
+        XCTAssertEqual(renderedRadius, expectedRadius, accuracy: 0.001)
     }
 }


### PR DESCRIPTION
# Corner-radius follow-ups

## Summary

- represent the corner-radius preference as an optional override, so the missing value continues to resolve from the current macOS version instead of being pinned on the next config save
- add an **OS default** action beside the slider; resetting removes the override from `config.json` and refreshes focus borders, brackets, and dim cut-outs live
- preserve the focused border's last stamped half-width expansion during radius refreshes, including the wider 2.5 px error border
- add regression coverage for OS-dependent resolution, explicit overrides, omitted persistence, and error-border refresh geometry

## Config and migration

- no schema bump is needed; `windowCornerRadius` remains optional and no new config key is introduced
- configs without `windowCornerRadius` stay in adaptive OS-default mode and keep omitting the key on later saves
- numeric values written by #15 remain explicit overrides for compatibility; choosing **OS default** removes that value so a later macOS upgrade can select the new default

## Tests

- full application Swift typecheck passed with the Command Line Tools toolchain (using a compile-only local Sparkle API stub)
- all app and test Swift sources passed frontend parsing
- `HyprMac.xcodeproj/project.pbxproj` passed `plutil -lint`
- `git diff --check` passed

`xcodebuild test` was not available locally because this machine only has Xcode Command Line Tools, and SwiftLint is not installed. The focused XCTest regressions are included for the upstream full-Xcode run.

Follow-up to #15 and the maintainer notes in its merge review.
