### PR TITLE
Add shared Spotlight app activation with pre-launch layout reservation

### DIFF
--- a/HyprMac.xcodeproj/project.pbxproj
+++ b/HyprMac.xcodeproj/project.pbxproj
@@ -67,6 +67,15 @@
 		96FC11AF63A197C78BBE9E40 /* KeybindEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17ABB08FA82CF475A82AB3C5 /* KeybindEditorViewModel.swift */; };
 		98D72FEBD5773242B4F199B7 /* PollingSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18F440861EC1F33CEB326CB4 /* PollingSchedulerTests.swift */; };
 		9D75A3D3BAA41C0012711D6D /* UserConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A029C0AE0E8E5DEE2416684 /* UserConfig.swift */; };
+		A100D762AD3341A583020001 /* AppIntentApplicationActivationBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200D762AD3341A583020001 /* AppIntentApplicationActivationBridge.swift */; };
+		A100D762AD3341A583020002 /* HyprMacAppShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200D762AD3341A583020002 /* HyprMacAppShortcuts.swift */; };
+		A100D762AD3341A583020003 /* InstalledApplicationCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200D762AD3341A583020003 /* InstalledApplicationCatalog.swift */; };
+		A100D762AD3341A583020004 /* InstalledApplicationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200D762AD3341A583020004 /* InstalledApplicationEntity.swift */; };
+		A100D762AD3341A583020005 /* OpenApplicationWithHyprMacIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200D762AD3341A583020005 /* OpenApplicationWithHyprMacIntent.swift */; };
+		A100D762AD3341A583020006 /* ApplicationLaunchVisibilityGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200D762AD3341A583020006 /* ApplicationLaunchVisibilityGuard.swift */; };
+		A100D762AD3341A583020007 /* ApplicationActivationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200D762AD3341A583020007 /* ApplicationActivationCoordinatorTests.swift */; };
+		A100D762AD3341A583020008 /* LaunchLayoutReservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200D762AD3341A583020008 /* LaunchLayoutReservationTests.swift */; };
+		A100D762AD3341A583020009 /* ApplicationLaunchVisibilityGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200D762AD3341A583020009 /* ApplicationLaunchVisibilityGuardTests.swift */; };
 		A34F6208901205B1100F08AE /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB697B2619BEB7E2434E157E /* WelcomeView.swift */; };
 		A78F1FAAB49BEEEAE2A1844D /* ResizeDirectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E97E23BFC7B85A7E6BF506 /* ResizeDirectionTests.swift */; };
 		AC01521BE9F2030CF901A2C9 /* DragSwapHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB2A500B78D0C9A7FAE6173 /* DragSwapHandler.swift */; };
@@ -177,6 +186,15 @@
 		9EBC04818743A6F6231119AB /* WelcomeContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeContent.swift; sourceTree = "<group>"; };
 		9F1105FD856A5A007D619120 /* FrameReadbackPoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameReadbackPoller.swift; sourceTree = "<group>"; };
 		A034E555A586C182E187021F /* HyprMacApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyprMacApp.swift; sourceTree = "<group>"; };
+		A200D762AD3341A583020001 /* AppIntentApplicationActivationBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentApplicationActivationBridge.swift; sourceTree = "<group>"; };
+		A200D762AD3341A583020002 /* HyprMacAppShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HyprMacAppShortcuts.swift; sourceTree = "<group>"; };
+		A200D762AD3341A583020003 /* InstalledApplicationCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstalledApplicationCatalog.swift; sourceTree = "<group>"; };
+		A200D762AD3341A583020004 /* InstalledApplicationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstalledApplicationEntity.swift; sourceTree = "<group>"; };
+		A200D762AD3341A583020005 /* OpenApplicationWithHyprMacIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenApplicationWithHyprMacIntent.swift; sourceTree = "<group>"; };
+		A200D762AD3341A583020006 /* ApplicationLaunchVisibilityGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLaunchVisibilityGuard.swift; sourceTree = "<group>"; };
+		A200D762AD3341A583020007 /* ApplicationActivationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationActivationCoordinatorTests.swift; sourceTree = "<group>"; };
+		A200D762AD3341A583020008 /* LaunchLayoutReservationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchLayoutReservationTests.swift; sourceTree = "<group>"; };
+		A200D762AD3341A583020009 /* ApplicationLaunchVisibilityGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLaunchVisibilityGuardTests.swift; sourceTree = "<group>"; };
 		A36D359F723D63F2E6036D15 /* AppLauncherManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLauncherManager.swift; sourceTree = "<group>"; };
 		A7BD70717FD497B0899FBCE5 /* KeybindOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindOverlayController.swift; sourceTree = "<group>"; };
 		AF93D6331BC4826814BB7007 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -239,6 +257,7 @@
 				3F5155705392561940307378 /* HyprMac.entitlements */,
 				E5557F0D5040AE48CF5031E4 /* Info.plist */,
 				0FDAA32D76C8731CF9963ED4 /* App */,
+				A300D762AD3341A583020001 /* AppIntents */,
 				2D672DB6C1094B3A58DB9AD7 /* Core */,
 				98EADA0C8EECA495751C4BA5 /* Models */,
 				94F32CDCB78265FB55BA2241 /* Persistence */,
@@ -292,6 +311,7 @@
 			children = (
 				8B8FB422F1864D03E43BF91E /* AccessibilityManager.swift */,
 				A36D359F723D63F2E6036D15 /* AppLauncherManager.swift */,
+				A200D762AD3341A583020006 /* ApplicationLaunchVisibilityGuard.swift */,
 				1BB92BD985DAC4292DE1C57F /* CursorManager.swift */,
 				84FD66866CE44F180CAA03C7 /* DimmingOverlay.swift */,
 				593D96A7340421A4588DE5D5 /* DisplayManager.swift */,
@@ -408,9 +428,23 @@
 			);
 			sourceTree = "<group>";
 		};
+		A300D762AD3341A583020001 /* AppIntents */ = {
+			isa = PBXGroup;
+			children = (
+				A200D762AD3341A583020001 /* AppIntentApplicationActivationBridge.swift */,
+				A200D762AD3341A583020002 /* HyprMacAppShortcuts.swift */,
+				A200D762AD3341A583020003 /* InstalledApplicationCatalog.swift */,
+				A200D762AD3341A583020004 /* InstalledApplicationEntity.swift */,
+				A200D762AD3341A583020005 /* OpenApplicationWithHyprMacIntent.swift */,
+			);
+			path = AppIntents;
+			sourceTree = "<group>";
+		};
 		B0A0AB76785D9D6DA70BB530 /* HyprMacTests */ = {
 			isa = PBXGroup;
 			children = (
+				A200D762AD3341A583020007 /* ApplicationActivationCoordinatorTests.swift */,
+				A200D762AD3341A583020009 /* ApplicationLaunchVisibilityGuardTests.swift */,
 				16AC17310FABAC0CFEA327E7 /* BSPNodeTests.swift */,
 				1A85F3FF392095FDDB36DAB7 /* BSPTestSupport.swift */,
 				2796ACDEF732F4AB5C0EC77C /* BSPTreeTests.swift */,
@@ -422,6 +456,7 @@
 				C0C8D3EAFB70C82B163D2DAA /* ForceInsertWindowFallbackTests.swift */,
 				43D8A7DDD1BB3D497B6F88EF /* HandleDisplayChangeTests.swift */,
 				D3521F94E7B0FCC0E03B50D3 /* KeybindDecoderToleranceTests.swift */,
+				A200D762AD3341A583020008 /* LaunchLayoutReservationTests.swift */,
 				298318CA91C080E2C130A4DE /* LayoutEngineTests.swift */,
 				18F440861EC1F33CEB326CB4 /* PollingSchedulerTests.swift */,
 				12DCA371573CAAC4B23A96AA /* PrepareLayoutMutationTests.swift */,
@@ -588,8 +623,10 @@
 				2F7C20004633B3B6A8CCF6D6 /* Action.swift in Sources */,
 				4F7E79CBC44F654BDF24C05B /* ActionDispatcher.swift in Sources */,
 				29EF01F22534CC2B51FE0390 /* AppDelegate.swift in Sources */,
+				A100D762AD3341A583020001 /* AppIntentApplicationActivationBridge.swift in Sources */,
 				E916A4BC377A1C882DB198AD /* AppLauncherEditorSheet.swift in Sources */,
 				440732216A02AA6BC39588CC /* AppLauncherManager.swift in Sources */,
+				A100D762AD3341A583020006 /* ApplicationLaunchVisibilityGuard.swift in Sources */,
 				F085027AE374E48959DEEB48 /* BSPNode.swift in Sources */,
 				F2B3AC04608B7F92C811A44A /* BSPTree.swift in Sources */,
 				7FB049BFF3F0B8E61B5D9177 /* BundleIDPicker.swift in Sources */,
@@ -617,7 +654,10 @@
 				33D18D1F45F3CB1C3E2FDA03 /* HotkeyManager.swift in Sources */,
 				3564F2FDA0E1E1BEA5FDFCA8 /* HyprKey.swift in Sources */,
 				E75F4991C42DA20A1A207121 /* HyprMacApp.swift in Sources */,
+				A100D762AD3341A583020002 /* HyprMacAppShortcuts.swift in Sources */,
 				DFB503500879F243DD9C3FC1 /* HyprWindow.swift in Sources */,
+				A100D762AD3341A583020003 /* InstalledApplicationCatalog.swift in Sources */,
+				A100D762AD3341A583020004 /* InstalledApplicationEntity.swift in Sources */,
 				28BD7C8DD76D02FBC83769F7 /* KeyBadgeViews.swift in Sources */,
 				D58328860E2249DD694C36CA /* KeyCodeUtils.swift in Sources */,
 				E49C450CFEE3A7BC692AA590 /* KeyRecorderView.swift in Sources */,
@@ -633,6 +673,7 @@
 				1CE8BFDB73C690ADABECD3C3 /* MenuBarView.swift in Sources */,
 				C59F755D984292EB1E5B57CD /* MinSizeMemory.swift in Sources */,
 				94D0B3F1FB21CB77289D4AF0 /* MouseTrackingManager.swift in Sources */,
+				A100D762AD3341A583020005 /* OpenApplicationWithHyprMacIntent.swift in Sources */,
 				59A1C07CD47B837E7F59A2D7 /* PermissionsGate.swift in Sources */,
 				87509383B627C5F0A3B32B23 /* PollingScheduler.swift in Sources */,
 				D181B66CA786C3A32097B09D /* ScratchpadController.swift in Sources */,
@@ -663,6 +704,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A100D762AD3341A583020007 /* ApplicationActivationCoordinatorTests.swift in Sources */,
+				A100D762AD3341A583020009 /* ApplicationLaunchVisibilityGuardTests.swift in Sources */,
 				049A911F001515424E52E5B9 /* BSPNodeTests.swift in Sources */,
 				0A95C40458C159F8851E03E4 /* BSPTestSupport.swift in Sources */,
 				4F220AC370184B0540805075 /* BSPTreeTests.swift in Sources */,
@@ -674,6 +717,7 @@
 				EAD93287EB51947EF49B40DE /* ForceInsertWindowFallbackTests.swift in Sources */,
 				C1CCA6C07D0B273CF3AB3D6C /* HandleDisplayChangeTests.swift in Sources */,
 				D380E4A1BDD2AD4281299E72 /* KeybindDecoderToleranceTests.swift in Sources */,
+				A100D762AD3341A583020008 /* LaunchLayoutReservationTests.swift in Sources */,
 				15AB8B9331E6A03CDD991F3C /* LayoutEngineTests.swift in Sources */,
 				98D72FEBD5773242B4F199B7 /* PollingSchedulerTests.swift in Sources */,
 				CAF7E4C0660A5075D1D9DD62 /* PrepareLayoutMutationTests.swift in Sources */,

--- a/HyprMac/App/AppDelegate.swift
+++ b/HyprMac/App/AppDelegate.swift
@@ -24,6 +24,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
 
+        if #available(macOS 15.0, *) {
+            // Refresh dynamic app-entity phrases on launch. Spotlight owns
+            // ranking and Quick Keys; this only publishes the public action.
+            HyprMacAppShortcuts.updateAppShortcutParameters()
+        }
+
         hyprLog(.debug, .lifecycle, "bundle: \(Bundle.main.bundleIdentifier ?? "?")")
         hyprLog(.debug, .lifecycle, "AXIsProcessTrusted=\(AXIsProcessTrusted())")
 
@@ -74,9 +80,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// version-bump welcome decision.
     func startWindowManager() {
         let config = UserConfig.shared
-        windowManager = WindowManager(config: config)
+        let manager = WindowManager(config: config)
+        windowManager = manager
         if config.enabled {
-            windowManager?.start()
+            manager.start()
         }
         checkFirstLaunchOrUpdate()
     }

--- a/HyprMac/AppIntents/AppIntentApplicationActivationBridge.swift
+++ b/HyprMac/AppIntents/AppIntentApplicationActivationBridge.swift
@@ -1,0 +1,115 @@
+// Process-local bridge from App Intents into HyprMac's activation coordinator.
+
+import Foundation
+
+/// Keeps App Intents independent from AppKit launching and window-management
+/// details. The app installs its long-lived `ApplicationActivating` service as
+/// early as possible during launch; the bridge deliberately owns it weakly.
+@MainActor
+enum AppIntentApplicationActivationBridge {
+    private struct PendingActivation {
+        var handle: ApplicationActivationHandle?
+        let continuation: CheckedContinuation<ApplicationActivationResult, Never>
+    }
+
+    private static weak var service: (any ApplicationActivating)?
+    private static var serviceIsReady = false
+    private static var pendingActivations: [UUID: PendingActivation] = [:]
+
+    static func install(_ service: any ApplicationActivating, ready: Bool = true) {
+        self.service = service
+        serviceIsReady = ready
+    }
+
+    static func markReady(_ candidate: any ApplicationActivating) {
+        guard let installedService = service, installedService === candidate else { return }
+        serviceIsReady = true
+    }
+
+    static func remove(_ candidate: any ApplicationActivating) {
+        guard let installedService = service, installedService === candidate else { return }
+        service = nil
+        serviceIsReady = false
+        cancelAllPendingActivations()
+    }
+
+    /// Await the callback API while retaining its cancellation handle.
+    static func activate(bundleIdentifier: String) async throws -> ApplicationActivationResult {
+        let service = try await readyService()
+        // A stop/replacement can run while the readiness await resumes.
+        guard self.service === service, serviceIsReady else {
+            throw AppIntentActivationBridgeError.serviceUnavailable
+        }
+        guard !Task.isCancelled else { return .cancelled }
+
+        let requestID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                // Register before calling the service: valid implementations
+                // may complete synchronously (for example, `.unavailable`).
+                pendingActivations[requestID] = PendingActivation(
+                    handle: nil,
+                    continuation: continuation
+                )
+                let handle = service.activate(
+                    bundleID: bundleIdentifier,
+                    source: .spotlight
+                ) { result in
+                    Task { @MainActor in
+                        finish(requestID: requestID, result: result)
+                    }
+                }
+                if pendingActivations[requestID] != nil {
+                    pendingActivations[requestID]?.handle = handle
+                }
+            }
+        } onCancel: {
+            Task { @MainActor in
+                cancel(requestID: requestID)
+            }
+        }
+    }
+
+    /// A background App Intent can arrive before launch has installed the
+    /// manager or completed its first window snapshot. Yield the main actor
+    /// while waiting; never launch an app against partially initialized state.
+    private static func readyService() async throws -> any ApplicationActivating {
+        let deadline = ProcessInfo.processInfo.systemUptime + 2.0
+        while true {
+            try Task.checkCancellation()
+            if serviceIsReady, let service { return service }
+            guard ProcessInfo.processInfo.systemUptime < deadline else {
+                throw AppIntentActivationBridgeError.serviceUnavailable
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+    }
+
+    private static func finish(requestID: UUID, result: ApplicationActivationResult) {
+        guard let pending = pendingActivations.removeValue(forKey: requestID) else { return }
+        pending.continuation.resume(returning: result)
+    }
+
+    private static func cancel(requestID: UUID) {
+        guard let pending = pendingActivations.removeValue(forKey: requestID) else { return }
+        pending.handle?.cancel()
+        pending.continuation.resume(returning: .cancelled)
+    }
+
+    private static func cancelAllPendingActivations() {
+        let pending = Array(pendingActivations.values)
+        pendingActivations.removeAll()
+        for activation in pending {
+            activation.handle?.cancel()
+            activation.continuation.resume(returning: .cancelled)
+        }
+    }
+}
+
+enum AppIntentActivationBridgeError: LocalizedError {
+    case serviceUnavailable
+
+    var errorDescription: String? {
+        "HyprMac's window activation service is not ready. Open HyprMac and try again."
+    }
+}

--- a/HyprMac/AppIntents/HyprMacAppShortcuts.swift
+++ b/HyprMac/AppIntents/HyprMacAppShortcuts.swift
@@ -1,0 +1,25 @@
+// Makes HyprMac's central activation action discoverable across the system.
+
+import AppIntents
+
+/// App Shortcut phrases include both a generic entry point and parameterized
+/// variants. The generic phrase remains useful for apps outside the suggested
+/// entity set; Spotlight asks for the required application interactively.
+@available(macOS 15.0, *)
+struct HyprMacAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: OpenApplicationWithHyprMacIntent(),
+            phrases: [
+                "Open an app with \(.applicationName)",
+                "Open \(\.$application) with \(.applicationName)",
+                "Launch \(\.$application) with \(.applicationName)",
+                "Use \(.applicationName) to open \(\.$application)",
+            ],
+            shortTitle: "Open App",
+            systemImageName: "macwindow"
+        )
+    }
+
+    static let shortcutTileColor: ShortcutTileColor = .blue
+}

--- a/HyprMac/AppIntents/InstalledApplicationCatalog.swift
+++ b/HyprMac/AppIntents/InstalledApplicationCatalog.swift
@@ -1,0 +1,220 @@
+// Public-API-only discovery of launchable macOS applications for App Intents.
+
+import AppKit
+import Foundation
+
+/// The small, Sendable value the Spotlight entity layer needs for an app.
+struct InstalledApplicationRecord: Hashable, Sendable {
+    let bundleIdentifier: String
+    let displayName: String
+    let url: URL
+}
+
+/// Discovers applications without relying on private LaunchServices symbols.
+///
+/// There is no public API that enumerates every registered application. The
+/// catalog therefore scans the standard application folders, then uses
+/// `NSWorkspace` only to resolve persistent bundle identifiers. Apps installed
+/// elsewhere can still be restored by identifier when LaunchServices knows
+/// about them.
+actor InstalledApplicationCatalog {
+    static let shared = InstalledApplicationCatalog()
+
+    static var defaultSearchRoots: [URL] {
+        let fileManager = FileManager.default
+        return [
+            fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Applications", isDirectory: true),
+            URL(fileURLWithPath: "/Applications", isDirectory: true),
+            URL(fileURLWithPath: "/System/Applications", isDirectory: true),
+            URL(fileURLWithPath: "/System/Library/CoreServices", isDirectory: true),
+        ]
+    }
+
+    private let fileManager: FileManager
+    private let searchRoots: [URL]
+    private let cacheLifetime: TimeInterval
+    private var cachedApplications: [InstalledApplicationRecord]?
+    private var cacheDate: Date?
+
+    init(
+        searchRoots: [URL] = InstalledApplicationCatalog.defaultSearchRoots,
+        fileManager: FileManager = .default,
+        cacheLifetime: TimeInterval = 300
+    ) {
+        self.searchRoots = searchRoots
+        self.fileManager = fileManager
+        self.cacheLifetime = cacheLifetime
+    }
+
+    /// Return the cached catalog, rescanning after the short cache lifetime.
+    func applications(forceRefresh: Bool = false) -> [InstalledApplicationRecord] {
+        if !forceRefresh,
+           let cachedApplications,
+           let cacheDate,
+           Date().timeIntervalSince(cacheDate) < cacheLifetime {
+            return cachedApplications
+        }
+
+        let applications = scanSearchRoots()
+        cachedApplications = applications
+        cacheDate = Date()
+        return applications
+    }
+
+    /// Resolve stable entity identifiers while preserving the caller's order.
+    func applications(for bundleIdentifiers: [String]) async -> [InstalledApplicationRecord] {
+        var byIdentifier = Dictionary(
+            uniqueKeysWithValues: applications().map { ($0.bundleIdentifier, $0) }
+        )
+
+        for identifier in bundleIdentifiers where byIdentifier[identifier] == nil {
+            guard let url = await applicationURL(for: identifier),
+                  let application = application(at: url) else { continue }
+            byIdentifier[identifier] = application
+        }
+
+        return bundleIdentifiers.compactMap { byIdentifier[$0] }
+    }
+
+    /// Search by the user-visible name or bundle identifier.
+    func applications(matching query: String, limit: Int = 50) -> [InstalledApplicationRecord] {
+        let normalizedQuery = Self.normalized(query)
+        guard !normalizedQuery.isEmpty else {
+            return Array(applications().prefix(max(0, limit)))
+        }
+
+        return applications()
+            .compactMap { application -> (InstalledApplicationRecord, Int)? in
+                guard let score = Self.matchScore(application, query: normalizedQuery) else {
+                    return nil
+                }
+                return (application, score)
+            }
+            .sorted { lhs, rhs in
+                if lhs.1 != rhs.1 { return lhs.1 < rhs.1 }
+                return Self.sortsBefore(lhs.0, rhs.0)
+            }
+            .prefix(max(0, limit))
+            .map(\.0)
+    }
+
+    /// Stable suggestions also suit the App Shortcut parameter snapshot;
+    /// launching or quitting an app does not invalidate that snapshot.
+    func suggestedApplications(limit: Int = 24) -> [InstalledApplicationRecord] {
+        Array(applications().prefix(max(0, limit)))
+    }
+
+    func invalidate() {
+        cachedApplications = nil
+        cacheDate = nil
+    }
+
+    private func scanSearchRoots() -> [InstalledApplicationRecord] {
+        var byIdentifier: [String: InstalledApplicationRecord] = [:]
+        let resourceKeys: [URLResourceKey] = [.isDirectoryKey, .isPackageKey]
+
+        for root in searchRoots where fileManager.fileExists(atPath: root.path) {
+            guard let enumerator = fileManager.enumerator(
+                at: root,
+                includingPropertiesForKeys: resourceKeys,
+                options: [.skipsHiddenFiles, .skipsPackageDescendants],
+                errorHandler: { _, _ in true }
+            ) else { continue }
+
+            var candidates: [URL] = []
+            for case let url as URL in enumerator {
+                guard url.pathExtension.caseInsensitiveCompare("app") == .orderedSame else { continue }
+                candidates.append(url)
+            }
+
+            // FileManager does not promise enumeration order. Sorting within
+            // each priority-ordered root makes duplicate bundle IDs stable.
+            for url in candidates.sorted(by: { $0.path < $1.path }) {
+                guard let application = application(at: url),
+                      byIdentifier[application.bundleIdentifier] == nil else { continue }
+                byIdentifier[application.bundleIdentifier] = application
+            }
+        }
+
+        return byIdentifier.values.sorted(by: Self.sortsBefore)
+    }
+
+    private func application(at url: URL) -> InstalledApplicationRecord? {
+        let canonicalURL = url.standardizedFileURL.resolvingSymlinksInPath()
+        guard let bundle = Bundle(url: canonicalURL),
+              bundle.executableURL != nil,
+              let rawIdentifier = bundle.bundleIdentifier else { return nil }
+
+        let identifier = rawIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !identifier.isEmpty else { return nil }
+
+        if let packageType = bundle.object(forInfoDictionaryKey: "CFBundlePackageType") as? String,
+           packageType != "APPL" {
+            return nil
+        }
+        if (bundle.object(forInfoDictionaryKey: "LSBackgroundOnly") as? Bool) == true {
+            return nil
+        }
+        if (bundle.object(forInfoDictionaryKey: "LSUIElement") as? Bool) == true {
+            return nil
+        }
+
+        let displayName = Self.nonEmptyString(bundle.object(forInfoDictionaryKey: "CFBundleDisplayName"))
+            ?? Self.nonEmptyString(bundle.object(forInfoDictionaryKey: "CFBundleName"))
+            ?? canonicalURL.deletingPathExtension().lastPathComponent
+
+        return InstalledApplicationRecord(
+            bundleIdentifier: identifier,
+            displayName: displayName,
+            url: canonicalURL
+        )
+    }
+
+    private func applicationURL(for bundleIdentifier: String) async -> URL? {
+        await MainActor.run {
+            NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
+        }
+    }
+
+    private static func nonEmptyString(_ value: Any?) -> String? {
+        guard let value = value as? String else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func normalized(_ value: String) -> String {
+        value.folding(options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive], locale: .current)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func matchScore(
+        _ application: InstalledApplicationRecord,
+        query: String
+    ) -> Int? {
+        let name = normalized(application.displayName)
+        let identifier = normalized(application.bundleIdentifier)
+        let terms = query.split(whereSeparator: \Character.isWhitespace).map(String.init)
+
+        guard terms.allSatisfy({ name.contains($0) || identifier.contains($0) }) else {
+            return nil
+        }
+
+        if name == query { return 0 }
+        if identifier == query { return 1 }
+        if name.hasPrefix(query) { return 10 }
+        if name.split(whereSeparator: \Character.isWhitespace).contains(where: { $0.hasPrefix(query) }) {
+            return 20
+        }
+        if name.contains(query) { return 30 }
+        return 40
+    }
+
+    private static func sortsBefore(
+        _ lhs: InstalledApplicationRecord,
+        _ rhs: InstalledApplicationRecord
+    ) -> Bool {
+        let nameComparison = lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName)
+        if nameComparison != .orderedSame { return nameComparison == .orderedAscending }
+        return lhs.bundleIdentifier < rhs.bundleIdentifier
+    }
+}

--- a/HyprMac/AppIntents/InstalledApplicationEntity.swift
+++ b/HyprMac/AppIntents/InstalledApplicationEntity.swift
@@ -1,0 +1,64 @@
+// App Intents representation of an installed application.
+
+import AppIntents
+import Foundation
+
+/// A persistent application choice exposed to Shortcuts and Spotlight.
+///
+/// Bundle identifiers are stable across app moves and updates, unlike paths.
+/// The query resolves the current path and display name whenever the system
+/// restores an entity from a previous invocation.
+struct InstalledApplicationEntity: AppEntity, Hashable {
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Application")
+    static let defaultQuery = InstalledApplicationQuery()
+
+    let id: String
+    let displayName: String
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: "\(displayName)",
+            subtitle: "\(id)",
+            image: .init(systemName: "app")
+        )
+    }
+
+    init(id: String, displayName: String) {
+        self.id = id
+        self.displayName = displayName
+    }
+
+    init(_ application: InstalledApplicationRecord) {
+        self.init(id: application.bundleIdentifier, displayName: application.displayName)
+    }
+}
+
+/// Supplies a small suggestion list and full typed search on demand.
+struct InstalledApplicationQuery: EntityStringQuery {
+    private let catalog: InstalledApplicationCatalog
+
+    init() {
+        catalog = .shared
+    }
+
+    /// Injectable for deterministic unit tests without changing production use.
+    init(catalog: InstalledApplicationCatalog) {
+        self.catalog = catalog
+    }
+
+    func entities(for identifiers: [InstalledApplicationEntity.ID]) async throws
+        -> [InstalledApplicationEntity] {
+        await catalog.applications(for: identifiers).map(InstalledApplicationEntity.init)
+    }
+
+    func entities(matching string: String) async throws -> [InstalledApplicationEntity] {
+        if string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return try await suggestedEntities()
+        }
+        return await catalog.applications(matching: string).map(InstalledApplicationEntity.init)
+    }
+
+    func suggestedEntities() async throws -> [InstalledApplicationEntity] {
+        await catalog.suggestedApplications().map(InstalledApplicationEntity.init)
+    }
+}

--- a/HyprMac/AppIntents/OpenApplicationWithHyprMacIntent.swift
+++ b/HyprMac/AppIntents/OpenApplicationWithHyprMacIntent.swift
@@ -1,0 +1,81 @@
+// Spotlight and Shortcuts action for opening an application through HyprMac.
+
+import AppIntents
+import Foundation
+
+/// A generic action whose application parameter is supplied by the dynamic
+/// installed-app query. Spotlight can run this action directly on macOS 26.
+@available(macOS 15.0, *)
+struct OpenApplicationWithHyprMacIntent: AppIntent, PredictableIntent {
+    static let title: LocalizedStringResource = "Open App with HyprMac"
+    static let description = IntentDescription(
+        "Reveal and position an installed application's window with HyprMac.",
+        categoryName: "Window Management",
+        searchKeywords: ["open", "launch", "focus", "app", "window"]
+    )
+
+    @Parameter(
+        title: "Application",
+        description: "The application for HyprMac to open or reveal.",
+        requestValueDialog: "Which application should HyprMac open?"
+    )
+    var application: InstalledApplicationEntity
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Open \(\.$application) with HyprMac")
+    }
+
+    /// Keep HyprMac's accessory app in the background. `supportedModes` is
+    /// only present in the macOS 26 SDK, while this project intentionally
+    /// remains buildable with Xcode 16; the established compatibility
+    /// property has the same background-only behavior on both SDKs.
+    static var openAppWhenRun: Bool { false }
+
+    static var predictionConfiguration: some IntentPredictionConfiguration {
+        IntentPrediction(parameters: \.$application) { application in
+            DisplayRepresentation(title: "Open \(application.displayName) with HyprMac")
+        }
+    }
+
+    init() {}
+
+    init(application: InstalledApplicationEntity) {
+        self.application = application
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let result = try await AppIntentApplicationActivationBridge.activate(
+            bundleIdentifier: application.id
+        )
+
+        switch result {
+        case .activated, .openedWithoutWindow:
+            return .result(dialog: "Opened \(application.displayName) with HyprMac.")
+        case .unavailable:
+            throw OpenApplicationIntentError.applicationUnavailable(application.displayName)
+        case .timedOut:
+            throw OpenApplicationIntentError.timedOut(application.displayName)
+        case .failed(let message):
+            throw OpenApplicationIntentError.activationFailed(application.displayName, message)
+        case .cancelled:
+            throw CancellationError()
+        }
+    }
+}
+
+private enum OpenApplicationIntentError: LocalizedError {
+    case applicationUnavailable(String)
+    case timedOut(String)
+    case activationFailed(String, String)
+
+    var errorDescription: String? {
+        switch self {
+        case .applicationUnavailable(let name):
+            return "\(name) is no longer available to HyprMac."
+        case .timedOut(let name):
+            return "HyprMac did not find a manageable window for \(name) in time."
+        case .activationFailed(let name, let reason):
+            return "HyprMac could not open \(name): \(reason)"
+        }
+    }
+}

--- a/HyprMac/Core/AccessibilityManager.swift
+++ b/HyprMac/Core/AccessibilityManager.swift
@@ -5,6 +5,25 @@
 
 import Cocoa
 
+/// A window visible to the app-activation workflow, including windows that
+/// are currently minimized or belong to a hidden application.
+struct ApplicationWindowCandidate: Equatable {
+    let windowID: CGWindowID
+    let isMinimized: Bool
+    let isMain: Bool
+    let isFocused: Bool
+}
+
+/// AX distinguishes a confirmed empty window list from an unreadable one.
+/// The activation workflow must never reopen an app merely because AX was
+/// temporarily unavailable; doing so can create duplicate documents.
+enum ApplicationWindowInventory: Equatable {
+    // Includes non-standard/modal windows: a filtered list is not evidence
+    // that the app has no window and should receive another reopen event.
+    case available(windows: [ApplicationWindowCandidate], hasUnaddressableWindows: Bool)
+    case unavailable
+}
+
 /// Wrapper around the macOS Accessibility (AX) API.
 ///
 /// Owns the AX↔CG mapping path: each visible window is enumerated via
@@ -110,6 +129,132 @@ class AccessibilityManager {
         var wid: CGWindowID = 0
         let err = _AXUIElementGetWindow(element, &wid)
         return err == .success && wid != 0 ? wid : nil
+    }
+
+    /// Enumerate standard windows for one app without requiring them to be
+    /// on-screen. This is intentionally separate from `getAllWindows()`: the
+    /// latter is the visible-desktop discovery source, while activation also
+    /// needs to reason about Cmd-H and minimized windows.
+    func activationWindowInventory(for pid: pid_t) -> ApplicationWindowInventory {
+        guard AXIsProcessTrusted() else { return .unavailable }
+
+        let appElement = AXUIElementCreateApplication(pid)
+        var value: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            appElement, kAXWindowsAttribute as CFString, &value
+        ) == .success, let windows = value as? [AXUIElement] else {
+            return .unavailable
+        }
+
+        var candidates: [ApplicationWindowCandidate] = []
+        var hasUnaddressableWindows = false
+        for window in windows {
+            guard isStandardActivationWindow(window) else {
+                hasUnaddressableWindows = true
+                continue
+            }
+            guard let id = windowID(for: window) else {
+                // A real standard window exists, but cannot safely be routed.
+                // Preserve that distinction from a confirmed empty list.
+                hasUnaddressableWindows = true
+                continue
+            }
+            candidates.append(ApplicationWindowCandidate(
+                windowID: id,
+                isMinimized: boolAttribute(kAXMinimizedAttribute, of: window),
+                isMain: boolAttribute(kAXMainAttribute, of: window),
+                isFocused: boolAttribute(kAXFocusedAttribute, of: window)
+            ))
+        }
+
+        candidates.sort { $0.windowID < $1.windowID }
+        return .available(windows: candidates, hasUnaddressableWindows: hasUnaddressableWindows)
+    }
+
+    /// Resolve selected activation candidates back to `HyprWindow` values.
+    /// Unlike `getAllWindows()`, this works while the app is hidden or its
+    /// windows are minimized, which lets the normal discovery/tiling pipeline
+    /// prepare them before a controlled reveal.
+    func activationWindows(for pid: pid_t,
+                           matching ids: Set<CGWindowID>) -> [HyprWindow] {
+        guard AXIsProcessTrusted(), !ids.isEmpty else { return [] }
+
+        let appElement = AXUIElementCreateApplication(pid)
+        var value: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            appElement, kAXWindowsAttribute as CFString, &value
+        ) == .success, let windows = value as? [AXUIElement] else {
+            return []
+        }
+
+        let bundleID = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier
+        var result: [HyprWindow] = []
+        for element in windows where isStandardActivationWindow(element) {
+            guard let id = windowID(for: element), ids.contains(id) else { continue }
+            let window = HyprWindow(element: element, windowID: id, ownerPID: pid)
+            window.cachedFrame = axFrame(for: element)
+            window.seedMinimumSize(bundleIdentifier: bundleID)
+            result.append(window)
+        }
+        return result.sorted { $0.windowID < $1.windowID }
+    }
+
+    /// Resolve one selected window after reveal without walking every app's
+    /// AX tree on each retry. Keep normal discovery's on-screen/alpha checks;
+    /// a window on a different native Space is not ready for this route.
+    func visibleActivationWindow(for pid: pid_t, windowID: CGWindowID) -> HyprWindow? {
+        guard let app = NSRunningApplication(processIdentifier: pid),
+              app.activationPolicy == .regular, !app.isHidden, !app.isTerminated,
+              cgWindowsByPID()[pid]?.contains(where: {
+                  $0.windowID == windowID && $0.alpha > 0.01
+              }) == true,
+              let window = activationWindows(for: pid, matching: [windowID]).first,
+              window.cachedFrame != nil,
+              !boolAttribute(kAXMinimizedAttribute, of: window.element) else { return nil }
+        return window
+    }
+
+    /// Whether both geometry attributes can be set for a window. A hidden
+    /// pre-layout is attempted only when AX explicitly confirms this.
+    func canSetFrame(of window: HyprWindow) -> Bool {
+        var positionSettable = DarwinBoolean(false)
+        var sizeSettable = DarwinBoolean(false)
+        let positionResult = AXUIElementIsAttributeSettable(
+            window.element, kAXPositionAttribute as CFString, &positionSettable
+        )
+        let sizeResult = AXUIElementIsAttributeSettable(
+            window.element, kAXSizeAttribute as CFString, &sizeSettable
+        )
+        return positionResult == .success && positionSettable.boolValue
+            && sizeResult == .success && sizeSettable.boolValue
+    }
+
+    private func boolAttribute(_ name: String, of element: AXUIElement) -> Bool {
+        var value: AnyObject?
+        guard AXUIElementCopyAttributeValue(element, name as CFString, &value) == .success else {
+            return false
+        }
+        return (value as? NSNumber)?.boolValue ?? false
+    }
+
+    private func isStandardActivationWindow(_ element: AXUIElement) -> Bool {
+        var roleValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            element, kAXRoleAttribute as CFString, &roleValue
+        ) == .success, roleValue as? String == kAXWindowRole as String else {
+            return false
+        }
+
+        var subroleValue: AnyObject?
+        AXUIElementCopyAttributeValue(element, kAXSubroleAttribute as CFString, &subroleValue)
+        if let subrole = subroleValue as? String,
+           subrole != kAXStandardWindowSubrole as String {
+            return false
+        }
+
+        var modalValue: AnyObject?
+        AXUIElementCopyAttributeValue(element, kAXModalAttribute as CFString, &modalValue)
+        return !((modalValue as? NSNumber)?.boolValue ?? false)
     }
 
     /// Snapshot every visible normal window across all running apps.

--- a/HyprMac/Core/AppLauncherManager.swift
+++ b/HyprMac/Core/AppLauncherManager.swift
@@ -1,62 +1,863 @@
-// Launches an app by bundle ID, or activates and unminimizes its
-// existing windows if it is already running.
+// One request-scoped application activation pipeline shared by app-launch
+// hotkeys and the Spotlight App Intent. It chooses one concrete window,
+// prepares restorable windows before revealing them where macOS permits,
+// and treats all asynchronous workspace/AX callbacks as hints rather than
+// assuming they arrive in a particular order.
 
 import Cocoa
 
-/// Launch-or-focus helper for the `Action.launchApp` keybind.
-///
-/// Resolves an app by bundle identifier and routes through one of three
-/// paths: already running with windows → activate; already running
-/// with no windows → reopen the app (so `applicationOpenUntitledFile`
-/// can fire); not running → launch via `NSWorkspace.openApplication`.
-class AppLauncherManager {
-    /// Bring the app to the foreground, opening a window if needed.
-    /// No-op when the bundle ID does not resolve to an installed app.
-    func launchOrFocus(bundleID: String) {
-        // if already running, unhide/unminimize and activate
-        if let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).first {
-            if app.isHidden {
-                app.unhide()
-            }
+enum ApplicationActivationSource: Equatable {
+    case hotkey
+    case spotlight
+}
 
-            // unminimize any minimized windows
-            let pid = app.processIdentifier
-            let appRef = AXUIElementCreateApplication(pid)
-            var windowsRef: CFTypeRef?
-            var hasWindows = false
-            if AXUIElementCopyAttributeValue(appRef, kAXWindowsAttribute as CFString, &windowsRef) == .success,
-               let windows = windowsRef as? [AXUIElement] {
-                hasWindows = !windows.isEmpty
-                for window in windows {
-                    var minimized: CFTypeRef?
-                    if AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minimized) == .success,
-                       (minimized as? Bool) == true {
-                        AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, false as CFTypeRef)
+enum ApplicationActivationResult: Equatable {
+    case activated(windowID: CGWindowID)
+    case openedWithoutWindow
+    case unavailable
+    case timedOut
+    case failed(String)
+    case cancelled
+}
+
+/// Cancellation returned to async callers such as App Intents. Dropping a
+/// handle does not cancel the request; cancellation must be explicit.
+final class ApplicationActivationHandle {
+    private let lock = NSLock()
+    private var cancellation: (() -> Void)?
+
+    init(cancellation: @escaping () -> Void = {}) {
+        self.cancellation = cancellation
+    }
+
+    func cancel() {
+        lock.lock()
+        let action = cancellation
+        cancellation = nil
+        lock.unlock()
+        action?()
+    }
+}
+
+protocol ApplicationActivating: AnyObject {
+    @discardableResult
+    func activate(bundleID: String,
+                  source: ApplicationActivationSource,
+                  completion: @escaping (ApplicationActivationResult) -> Void)
+        -> ApplicationActivationHandle
+}
+
+protocol ApplicationActivationScheduledTask: AnyObject {
+    func cancel()
+}
+
+private final class DispatchActivationTask: ApplicationActivationScheduledTask {
+    private let item: DispatchWorkItem
+
+    init(item: DispatchWorkItem) {
+        self.item = item
+    }
+
+    func cancel() {
+        item.cancel()
+    }
+}
+
+struct ApplicationProcessSnapshot: Equatable {
+    let pid: pid_t
+    let isHidden: Bool
+    let isActive: Bool
+}
+
+enum ApplicationOpenResult: Equatable {
+    case opened(pid: pid_t)
+    case failed(String)
+}
+
+/// All operating-system effects are injected. Besides keeping the coordinator
+/// testable, this makes the safety boundary explicit: only bundle identifiers
+/// resolved by Launch Services can be opened, and no shell/private launch hook
+/// is involved.
+struct ApplicationActivationEnvironment {
+    var now: () -> TimeInterval
+    var application: (_ bundleID: String, _ preferredPID: pid_t?) -> ApplicationProcessSnapshot?
+    var applicationURL: (_ bundleID: String) -> URL?
+    var inventory: (_ pid: pid_t) -> ApplicationWindowInventory
+    var openApplication: (_ url: URL, _ hidden: Bool,
+                          _ completion: @escaping (ApplicationOpenResult) -> Void) -> Void
+    var unhide: (_ pid: pid_t) -> Bool
+    var unminimize: (_ pid: pid_t, _ windowID: CGWindowID) -> Bool
+    var activate: (_ pid: pid_t) -> Bool
+    var protectHiddenLaunch: (_ bundleID: String, _ timeout: TimeInterval)
+        -> ApplicationLaunchVisibilityProtecting
+    var schedule: (_ delay: TimeInterval, _ block: @escaping () -> Void)
+        -> ApplicationActivationScheduledTask
+
+    static func live(accessibility: AccessibilityManager,
+                     workspace: NSWorkspace = .shared) -> Self {
+        Self(
+            now: { ProcessInfo.processInfo.systemUptime },
+            application: { bundleID, preferredPID in
+                let apps = NSRunningApplication.runningApplications(
+                    withBundleIdentifier: bundleID
+                ).filter { !$0.isTerminated }
+                let selected: NSRunningApplication?
+                if let preferredPID {
+                    // Once a request owns a process, never silently migrate
+                    // to a second instance of the same application.
+                    selected = apps.first { $0.processIdentifier == preferredPID }
+                } else {
+                    selected = apps.sorted {
+                        if $0.isActive != $1.isActive { return $0.isActive }
+                        if $0.isHidden != $1.isHidden { return !$0.isHidden }
+                        return $0.processIdentifier < $1.processIdentifier
+                    }.first
+                }
+                guard let selected else { return nil }
+                return ApplicationProcessSnapshot(
+                    pid: selected.processIdentifier,
+                    isHidden: selected.isHidden,
+                    isActive: selected.isActive
+                )
+            },
+            applicationURL: { workspace.urlForApplication(withBundleIdentifier: $0) },
+            inventory: { accessibility.activationWindowInventory(for: $0) },
+            openApplication: { url, hidden, completion in
+                let configuration = NSWorkspace.OpenConfiguration()
+                configuration.activates = !hidden
+                configuration.hides = hidden
+                // Keep the safe defaults: never create a second app instance,
+                // never hide other apps, and prompt if macOS requires consent.
+                workspace.openApplication(at: url, configuration: configuration) { app, error in
+                    DispatchQueue.main.async {
+                        if let error {
+                            completion(.failed(error.localizedDescription))
+                        } else if let app {
+                            completion(.opened(pid: app.processIdentifier))
+                        } else {
+                            completion(.failed("Launch Services returned no application"))
+                        }
                     }
                 }
+            },
+            unhide: { NSRunningApplication(processIdentifier: $0)?.unhide() ?? false },
+            unminimize: { pid, windowID in
+                guard let window = accessibility.activationWindows(
+                    for: pid, matching: [windowID]
+                ).first else { return false }
+                return AXUIElementSetAttributeValue(
+                    window.element,
+                    kAXMinimizedAttribute as CFString,
+                    kCFBooleanFalse
+                ) == .success
+            },
+            activate: { pid in
+                NSRunningApplication(processIdentifier: pid)?
+                    .activate(options: [.activateIgnoringOtherApps]) ?? false
+            },
+            protectHiddenLaunch: { bundleID, timeout in
+                ApplicationLaunchVisibilityGuard(bundleID: bundleID, timeout: timeout)
+            },
+            schedule: { delay, block in
+                let item = DispatchWorkItem(block: block)
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
+                return DispatchActivationTask(item: item)
+            }
+        )
+    }
+}
+
+enum ApplicationActivationClaim: Equatable {
+    /// The activation belongs to the in-flight request (or its short focus
+    /// tail), so WindowManager must skip the ordinary Dock-workspace path.
+    case claimed
+    /// A different app became active. The
+    /// request was cancelled, and the event should continue normally.
+    case cancelledForUserOverride
+    case unrelated
+}
+
+/// Serializes foreground ownership into one cancellable workflow.
+///
+/// macOS does not expose a public pre-map hook for other applications. The
+/// cold-launch path therefore uses `NSWorkspace.OpenConfiguration.hides` as
+/// a best-effort preparation window, validates through AX, and always fails
+/// open with an independent visibility backstop. Existing visible
+/// applications are never hidden.
+final class ApplicationActivationCoordinator: ApplicationActivating {
+    enum Phase: String {
+        case reservingSpace
+        case waitingForProcess
+        case waitingForWindows
+        case settlingWindows
+        case preparingWindows
+        case waitingForDiscovery
+        case routingWindow
+    }
+
+    private final class Request {
+        let id: UInt64
+        let bundleID: String
+        let source: ApplicationActivationSource
+        let startedAt: TimeInterval
+        var coldLaunch: Bool
+        var phase: Phase
+        var pid: pid_t?
+        var selectedWindowID: CGWindowID?
+        var subscribers: [UUID: (ApplicationActivationResult) -> Void]
+        var openIssued = false
+        var restoreIssued = false
+        var processSeenAt: TimeInterval?
+        var reopenIssuedAt: TimeInterval?
+        var firstWindowAt: TimeInterval?
+        var lastDiscoveryRequestAt: TimeInterval = -.infinity
+        var visibilityGuard: ApplicationLaunchVisibilityProtecting?
+        var probeTask: ApplicationActivationScheduledTask?
+        var settleTask: ApplicationActivationScheduledTask?
+        var timeoutTask: ApplicationActivationScheduledTask?
+
+        init(id: UInt64,
+             bundleID: String,
+             source: ApplicationActivationSource,
+             startedAt: TimeInterval,
+             coldLaunch: Bool,
+             subscriberID: UUID,
+             completion: @escaping (ApplicationActivationResult) -> Void) {
+            self.id = id
+            self.bundleID = bundleID
+            self.source = source
+            self.startedAt = startedAt
+            self.coldLaunch = coldLaunch
+            self.phase = coldLaunch ? .waitingForProcess : .waitingForWindows
+            self.subscribers = [subscriberID: completion]
+        }
+    }
+
+    private struct FocusClaim {
+        let requestID: UInt64
+        let pid: pid_t
+        let startedAt: TimeInterval
+        let expiresAt: TimeInterval
+    }
+
+    private let environment: ApplicationActivationEnvironment
+    private let hardTimeout: TimeInterval
+    private let windowQuietPeriod: TimeInterval
+    private let windowBurstCap: TimeInterval
+    private let noWindowGrace: TimeInterval
+    private var nextRequestID: UInt64 = 0
+    private var current: Request?
+    private var focusClaim: FocusClaim?
+
+    /// Runs the ordinary discovery/apply/tiling path with the selected app's
+    /// currently non-visible windows included. Returns true only when every
+    /// requested addressable window could be represented and safely laid out.
+    var prepareWindowsForReveal: (_ pid: pid_t, _ windowIDs: Set<CGWindowID>,
+                                  _ selectedWindowID: CGWindowID) -> Bool = { _, _, _ in false }
+
+    /// Reserve one predicted tile and let existing siblings accept their
+    /// new frames before Launch Services sees the cold-launch request.
+    /// Completion is bounded by the coordinator's overall timeout.
+    var reserveSpaceBeforeLaunch: (_ bundleID: String, _ requestID: UInt64,
+                                   _ completion: @escaping () -> Void) -> Void = { _, _, done in done() }
+
+    /// Release the speculative gap on every terminal path. The layout owner
+    /// reflows current state, never restores an obsolete workspace snapshot.
+    var finishLaunchReservation: (_ requestID: UInt64,
+                                  _ result: ApplicationActivationResult) -> Void = { _, _ in }
+
+    /// Route one exact, already prepared window through workspace/scratchpad
+    /// ownership and focus. `requestID` guards HyprWindow's delayed focus
+    /// reassertion against a later user override.
+    var routeWindow: (_ pid: pid_t, _ windowID: CGWindowID, _ requestID: UInt64) -> Bool = { _, _, _ in false }
+
+    /// Request a normal coalesced discovery pass after restore/reveal events.
+    var requestDiscovery: (_ delay: TimeInterval) -> Void = { _ in }
+
+    /// HyprMac's own focus history breaks AX main/focused ties without using
+    /// unstable enumeration order.
+    var lastFocusedWindowID: () -> CGWindowID = { 0 }
+
+    /// Prevents an App Intent from launching anything while HyprMac is
+    /// disabled, stopping, or still waiting for Accessibility permission.
+    var isAvailable: () -> Bool = { true }
+
+    init(environment: ApplicationActivationEnvironment,
+         hardTimeout: TimeInterval = 3.0,
+         windowQuietPeriod: TimeInterval = 0.12,
+         windowBurstCap: TimeInterval = 0.55,
+         noWindowGrace: TimeInterval = 0.6) {
+        self.environment = environment
+        self.hardTimeout = hardTimeout
+        self.windowQuietPeriod = windowQuietPeriod
+        self.windowBurstCap = windowBurstCap
+        self.noWindowGrace = noWindowGrace
+    }
+
+    convenience init(accessibility: AccessibilityManager) {
+        self.init(environment: .live(accessibility: accessibility))
+    }
+
+    @discardableResult
+    func activate(bundleID: String,
+                  source: ApplicationActivationSource,
+                  completion: @escaping (ApplicationActivationResult) -> Void)
+        -> ApplicationActivationHandle {
+        mainThreadOnly()
+
+        let normalized = bundleID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let subscriberID = UUID()
+        guard isAvailable(), !normalized.isEmpty, normalized.utf8.count <= 1024,
+              let url = environment.applicationURL(normalized) else {
+            // A newer user request supersedes the previous focus intent
+            // even when its saved application has since been uninstalled.
+            finishCurrent(with: .cancelled)
+            focusClaim = nil
+            completion(.unavailable)
+            return ApplicationActivationHandle()
+        }
+
+        if let request = current, request.bundleID == normalized {
+            request.subscribers[subscriberID] = completion
+            if request.phase != .reservingSpace { scheduleProbe(for: request, after: 0) }
+            return handle(for: request.id, subscriberID: subscriberID)
+        }
+
+        finishCurrent(with: .cancelled)
+        focusClaim = nil
+        nextRequestID &+= 1
+
+        let process = environment.application(normalized, nil)
+        let request = Request(
+            id: nextRequestID,
+            bundleID: normalized,
+            source: source,
+            startedAt: environment.now(),
+            coldLaunch: process == nil,
+            subscriberID: subscriberID,
+            completion: completion
+        )
+        request.pid = process?.pid
+        request.processSeenAt = process == nil ? nil : environment.now()
+        current = request
+        let requestID = request.id
+        request.timeoutTask = environment.schedule(hardTimeout) { [weak self] in
+            self?.timeout(requestID: requestID)
+        }
+
+        if process == nil {
+            request.phase = .reservingSpace
+            reserveSpaceBeforeLaunch(normalized, request.id) { [weak self, weak request] in
+                guard let self, let request,
+                      self.current === request, !request.openIssued else { return }
+                // Let already-queued user input cancel after preflow and
+                // before the irreversible request to start another app.
+                request.probeTask = self.environment.schedule(0) { [weak self, weak request] in
+                    guard let self, let request else { return }
+                    self.beginColdLaunch(request, url: url)
+                }
+            }
+        } else {
+            progress(request)
+        }
+
+        return handle(for: request.id, subscriberID: subscriberID)
+    }
+
+    /// Called before WindowManager applies its ordinary activation affordance.
+    @discardableResult
+    func noteApplicationActivated(bundleID: String?, pid: pid_t) -> ApplicationActivationClaim {
+        mainThreadOnly()
+        let now = environment.now()
+
+        if let request = current {
+            if matches(request, bundleID: bundleID, pid: pid) {
+                request.pid = pid
+                request.processSeenAt = request.processSeenAt ?? now
+                if request.phase != .reservingSpace { scheduleProbe(for: request, after: 0) }
+                return .claimed
             }
 
-            if hasWindows {
-                // windows exist, just activate
-                app.activate(options: [.activateAllWindows])
+            finish(request, with: .cancelled, keepFocusClaim: false)
+            return .cancelledForUserOverride
+        }
+
+        if let claim = focusClaim {
+            if now > claim.expiresAt {
+                focusClaim = nil
+            } else if pid == claim.pid {
+                return .claimed
             } else {
-                // no windows — re-open the app to trigger a new window
-                guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else { return }
-                NSWorkspace.shared.openApplication(at: url, configuration: .init()) { _, _ in }
+                focusClaim = nil
+            }
+        }
+        return .unrelated
+    }
+
+    func noteApplicationLaunched(bundleID: String?, pid: pid_t) {
+        mainThreadOnly()
+        guard let request = current,
+              matches(request, bundleID: bundleID, pid: pid) else { return }
+        request.pid = pid
+        request.processSeenAt = request.processSeenAt ?? environment.now()
+        requestDiscovery(0)
+        if request.phase != .reservingSpace { scheduleProbe(for: request, after: 0) }
+    }
+
+    func noteApplicationTerminated(bundleID: String?, pid: pid_t) {
+        mainThreadOnly()
+        guard let request = current,
+              matches(request, bundleID: bundleID, pid: pid) else { return }
+        finish(request, with: .failed("The application quit while opening"), keepFocusClaim: false)
+    }
+
+    func noteAXEvent(pid: pid_t) {
+        mainThreadOnly()
+        guard let request = current, request.pid == pid,
+              request.phase != .reservingSpace else { return }
+        requestDiscovery(0)
+        scheduleProbe(for: request, after: 0.03)
+    }
+
+    /// Called after discovery has updated workspace and cache ownership.
+    func noteDiscoveryCompleted() {
+        mainThreadOnly()
+        guard let request = current, request.phase == .waitingForDiscovery else { return }
+        // A failed route must not make poll -> probe -> poll a zero-delay
+        // loop while CG/AX still reports a restored window as off-screen.
+        scheduleProbe(for: request, after: 0.04)
+    }
+
+    /// Explicit user input invalidates both the in-flight request and the
+    /// delayed focus reassertion tail of a completed request.
+    func cancelForUserOverride(eventTimestamp: TimeInterval? = nil) {
+        mainThreadOnly()
+        // The Return/click that triggered a Spotlight intent may reach our
+        // main queue after that intent. Its original uptime timestamp keeps
+        // that older input from cancelling the action it just requested.
+        if let eventTimestamp, eventTimestamp > 0,
+           let startedAt = current?.startedAt ?? focusClaim?.startedAt,
+           eventTimestamp < startedAt { return }
+        focusClaim = nil
+        finishCurrent(with: .cancelled)
+    }
+
+    func stop() {
+        mainThreadOnly()
+        focusClaim = nil
+        finishCurrent(with: .cancelled)
+    }
+
+    func allowsFocusReassertion(for requestID: UInt64) -> Bool {
+        mainThreadOnly()
+        if current?.id == requestID { return true }
+        guard let claim = focusClaim, claim.requestID == requestID else { return false }
+        if environment.now() <= claim.expiresAt { return true }
+        focusClaim = nil
+        return false
+    }
+
+    // MARK: - state progression
+
+    private func beginColdLaunch(_ request: Request, url: URL) {
+        guard current === request, !request.openIssued else { return }
+        request.phase = .waitingForProcess
+        // The user/system may have started the same app during preflow.
+        // Never apply the hidden-launch configuration to an existing app.
+        if let process = environment.application(request.bundleID, request.pid) {
+            request.coldLaunch = false
+            request.pid = process.pid
+            request.processSeenAt = request.processSeenAt ?? environment.now()
+            finishLaunchReservation(request.id, .openedWithoutWindow)
+            progress(request)
+            return
+        }
+
+        request.openIssued = true
+        let remaining = max(0, hardTimeout - (environment.now() - request.startedAt))
+        let visibilityGuard = environment.protectHiddenLaunch(request.bundleID, remaining)
+        request.visibilityGuard = visibilityGuard
+        environment.openApplication(url, true) { [weak self] result in
+            // Cleanup outlives cancellation and the coordinator itself.
+            if case .opened(let pid) = result { visibilityGuard.applicationOpened(pid: pid) }
+            self?.handleOpenResult(result, request: request)
+        }
+    }
+
+    private func progress(_ request: Request) {
+        guard current === request, request.phase != .reservingSpace else { return }
+        guard let process = environment.application(request.bundleID, request.pid) else {
+            request.phase = .waitingForProcess
+            scheduleProbe(for: request, after: 0.05)
+            return
+        }
+        request.pid = process.pid
+        request.processSeenAt = request.processSeenAt ?? environment.now()
+        relinquishVisibilityProtectionIfRevealed(request, process: process)
+
+        switch environment.inventory(process.pid) {
+        case .unavailable:
+            // Unknown is not empty. For an existing app, fail safely by
+            // activating it; for a deliberately hidden cold launch, keep
+            // probing until the fail-open watchdog reveals it.
+            if request.coldLaunch && process.isHidden {
+                request.phase = .waitingForWindows
+                scheduleProbe(for: request, after: 0.06)
+            } else {
+                if process.isHidden { _ = environment.unhide(process.pid) }
+                _ = environment.activate(process.pid)
+                finish(request, with: .openedWithoutWindow)
+            }
+
+        case .available(let windows, let hasUnaddressableWindows):
+            if hasUnaddressableWindows {
+                // Let the app itself choose its modal/utility window. A
+                // standard document must not be raised over a dialog.
+                failOpen(request, process: process, result: .openedWithoutWindow)
+                return
+            }
+            if windows.isEmpty {
+                handleConfirmedNoWindows(request, process: process)
+                return
+            }
+
+            let selected = selectedWindow(for: request, from: windows)
+
+            if request.coldLaunch, !process.isHidden, !request.restoreIssued {
+                // Some apps ignore hides=true. Release the gap and let the
+                // normal visible discovery path take over; never hide again.
+                finishLaunchReservation(request.id, .openedWithoutWindow)
+            }
+
+            if request.coldLaunch && process.isHidden && !request.restoreIssued {
+                settleColdLaunch(request, windows: windows)
+            } else if process.isHidden || selected.isMinimized {
+                restoreExisting(request, process: process, windows: windows, selected: selected)
+            } else {
+                route(request, process: process, windowID: selected.windowID)
+            }
+        }
+    }
+
+    private func handleConfirmedNoWindows(_ request: Request,
+                                          process: ApplicationProcessSnapshot) {
+        if request.coldLaunch {
+            // The process exists but may not have completed restoration yet.
+            if environment.now() - (request.processSeenAt ?? environment.now()) < noWindowGrace {
+                request.phase = .waitingForWindows
+                scheduleProbe(for: request, after: 0.06)
+            } else {
+                failOpen(request, process: process, result: .openedWithoutWindow)
             }
             return
         }
 
-        // otherwise launch it
-        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else {
-            hyprLog(.debug, .lifecycle, "app not found: \(bundleID)")
+        if !request.openIssued {
+            guard let url = environment.applicationURL(request.bundleID) else {
+                finish(request, with: .unavailable, keepFocusClaim: false)
+                return
+            }
+            request.openIssued = true
+            request.reopenIssuedAt = environment.now()
+            request.phase = .waitingForWindows
+            environment.openApplication(url, false) { [weak self] result in
+                self?.handleOpenResult(result, request: request)
+            }
             return
         }
 
-        NSWorkspace.shared.openApplication(at: url, configuration: .init()) { _, error in
-            if let error = error {
-                hyprLog(.debug, .lifecycle, "failed to launch \(bundleID): \(error)")
+        if environment.now() - (request.reopenIssuedAt ?? request.startedAt) >= noWindowGrace {
+            _ = environment.activate(process.pid)
+            finish(request, with: .openedWithoutWindow)
+        } else {
+            scheduleProbe(for: request, after: 0.06)
+        }
+    }
+
+    private func settleColdLaunch(_ request: Request,
+                                  windows: [ApplicationWindowCandidate]) {
+        let now = environment.now()
+        if request.firstWindowAt == nil { request.firstWindowAt = now }
+        request.phase = .settlingWindows
+        request.settleTask?.cancel()
+
+        let elapsed = now - (request.firstWindowAt ?? now)
+        let delay = elapsed >= windowBurstCap ? 0 : windowQuietPeriod
+        request.settleTask = environment.schedule(delay) { [weak self, weak request] in
+            guard let self, let request, self.current === request else { return }
+            guard let process = self.environment.application(request.bundleID, request.pid) else {
+                self.scheduleProbe(for: request, after: 0.05)
+                return
+            }
+            switch self.environment.inventory(process.pid) {
+            case .unavailable:
+                self.scheduleProbe(for: request, after: 0.05)
+            case .available(let latest, let hasUnaddressable):
+                guard !latest.isEmpty, !hasUnaddressable else {
+                    self.failOpen(request, process: process, result: .openedWithoutWindow)
+                    return
+                }
+                self.prepareAndReveal(request, process: process, windows: latest)
             }
         }
+        _ = windows // the latest inventory is intentionally reread after quiet.
+    }
+
+    private func prepareAndReveal(_ request: Request,
+                                  process: ApplicationProcessSnapshot,
+                                  windows: [ApplicationWindowCandidate]) {
+        guard current === request else { return }
+        request.phase = .preparingWindows
+        let selected = selectedWindow(for: request, from: windows)
+        let ids = revealWindowIDs(windows, selectedWindowID: selected.windowID)
+
+        // Preparation is best-effort. Even when an app rejects geometry,
+        // reveal it and continue to exact-window routing, never strand it.
+        if !prepareWindowsForReveal(process.pid, ids, selected.windowID) {
+            finishLaunchReservation(request.id, .openedWithoutWindow)
+        }
+
+        // The app is allowed to ignore the initial hide request. Never fight
+        // it by hiding again; simply fall back to the visible path.
+        let latest = environment.application(request.bundleID, process.pid) ?? process
+        relinquishVisibilityProtectionIfRevealed(request, process: latest)
+        if latest.isHidden {
+            _ = environment.unhide(process.pid)
+        }
+        if selected.isMinimized {
+            _ = environment.unminimize(process.pid, selected.windowID)
+        }
+        request.restoreIssued = true
+        request.phase = .waitingForDiscovery
+        requestDiscovery(0)
+        scheduleProbe(for: request, after: 0.04)
+    }
+
+    private func restoreExisting(_ request: Request,
+                                 process: ApplicationProcessSnapshot,
+                                 windows: [ApplicationWindowCandidate],
+                                 selected: ApplicationWindowCandidate) {
+        guard !request.restoreIssued else {
+            // AX state changes are asynchronous. Do not focus a window while
+            // it is still reported hidden/minimized; the hard deadline remains
+            // the fail-open backstop if an app ignores the restore request.
+            request.phase = .waitingForDiscovery
+            scheduleProbe(for: request, after: 0.05)
+            return
+        }
+        request.restoreIssued = true
+
+        // A hidden app reveals all its windows, so prepare every addressable
+        // one. A visible app with one minimized target prepares only that one
+        // and never disturbs its other windows.
+        let ids: Set<CGWindowID> = process.isHidden
+            ? revealWindowIDs(windows, selectedWindowID: selected.windowID)
+            : [selected.windowID]
+        _ = prepareWindowsForReveal(process.pid, ids, selected.windowID)
+        if process.isHidden { _ = environment.unhide(process.pid) }
+        if selected.isMinimized { _ = environment.unminimize(process.pid, selected.windowID) }
+        request.phase = .waitingForDiscovery
+        requestDiscovery(0)
+        scheduleProbe(for: request, after: 0.04)
+    }
+
+    private func route(_ request: Request,
+                       process: ApplicationProcessSnapshot,
+                       windowID: CGWindowID) {
+        guard current === request else { return }
+        request.phase = .routingWindow
+        guard routeWindow(process.pid, windowID, request.id) else {
+            request.phase = .waitingForDiscovery
+            if environment.now() - request.lastDiscoveryRequestAt >= 0.12 {
+                request.lastDiscoveryRequestAt = environment.now()
+                requestDiscovery(0.06)
+            }
+            scheduleProbe(for: request, after: 0.08)
+            return
+        }
+        finish(request, with: .activated(windowID: windowID))
+    }
+
+    private func failOpen(_ request: Request,
+                          process: ApplicationProcessSnapshot,
+                          result: ApplicationActivationResult) {
+        guard current === request else { return }
+        if process.isHidden { _ = environment.unhide(process.pid) }
+        _ = environment.activate(process.pid)
+        requestDiscovery(0)
+        finish(request, with: result)
+    }
+
+    private func selectedWindow(for request: Request,
+                                from windows: [ApplicationWindowCandidate])
+        -> ApplicationWindowCandidate {
+        if let selectedID = request.selectedWindowID,
+           let selected = windows.first(where: { $0.windowID == selectedID }) {
+            return selected
+        }
+        let lastFocused = lastFocusedWindowID()
+        let selected = windows.min { lhs, rhs in
+            let left = (
+                lhs.isMinimized ? 1 : 0,
+                lhs.windowID == lastFocused ? 0 : 1,
+                lhs.isFocused ? 0 : 1,
+                lhs.isMain ? 0 : 1,
+                lhs.windowID
+            )
+            let right = (
+                rhs.isMinimized ? 1 : 0,
+                rhs.windowID == lastFocused ? 0 : 1,
+                rhs.isFocused ? 0 : 1,
+                rhs.isMain ? 0 : 1,
+                rhs.windowID
+            )
+            return left < right
+        }!
+        request.selectedWindowID = selected.windowID
+        return selected
+    }
+
+    private func revealWindowIDs(_ windows: [ApplicationWindowCandidate],
+                                 selectedWindowID: CGWindowID) -> Set<CGWindowID> {
+        // Cmd-H reveals the app's non-minimized windows, not every document
+        // in its Dock stack. Only the chosen minimized window gets a slot.
+        Set(windows.lazy.filter { !$0.isMinimized || $0.windowID == selectedWindowID }.map(\.windowID))
+    }
+
+    private func matches(_ request: Request, bundleID: String?, pid: pid_t) -> Bool {
+        if let expectedPID = request.pid { return pid == expectedPID }
+        return bundleID == request.bundleID
+    }
+
+    private func relinquishVisibilityProtectionIfRevealed(
+        _ request: Request, process: ApplicationProcessSnapshot
+    ) {
+        guard !process.isHidden else { return }
+        // Once visible, ownership is permanently released. A late launch
+        // callback must not undo a subsequent deliberate Cmd-H by the user.
+        request.visibilityGuard?.disarmAfterObservedReveal()
+        request.visibilityGuard = nil
+    }
+
+    private func handleOpenResult(_ result: ApplicationOpenResult, request: Request) {
+        mainThreadOnly()
+        guard current === request else {
+            // Never activate a stale launch: the user may already be typing
+            // in a different app. Only undo our own hidden-launch request.
+            request.visibilityGuard?.finish()
+            if request.visibilityGuard != nil, case .opened(let pid) = result {
+                _ = environment.unhide(pid)
+            }
+            return
+        }
+        switch result {
+        case .opened(let pid):
+            if let expectedPID = request.pid, expectedPID != pid {
+                if request.visibilityGuard != nil { _ = environment.unhide(pid) }
+                finish(request, with: .failed("Launch Services returned a different application process"),
+                       keepFocusClaim: false)
+                return
+            }
+            request.pid = pid
+            request.processSeenAt = request.processSeenAt ?? environment.now()
+            requestDiscovery(0)
+            scheduleProbe(for: request, after: 0)
+        case .failed(let message):
+            finish(request, with: .failed(message), keepFocusClaim: false)
+        }
+    }
+
+    private func scheduleProbe(for request: Request, after delay: TimeInterval) {
+        guard current === request else { return }
+        request.probeTask?.cancel()
+        request.probeTask = environment.schedule(delay) { [weak self, weak request] in
+            guard let self, let request, self.current === request else { return }
+            request.probeTask = nil
+            self.progress(request)
+        }
+    }
+
+    private func timeout(requestID: UInt64) {
+        mainThreadOnly()
+        guard let request = current, request.id == requestID else { return }
+        if request.phase != .reservingSpace,
+           let process = environment.application(request.bundleID, request.pid) {
+            request.pid = process.pid
+            if process.isHidden { _ = environment.unhide(process.pid) }
+            _ = environment.activate(process.pid)
+            requestDiscovery(0)
+        }
+        finish(request, with: .timedOut, keepFocusClaim: false)
+    }
+
+    private func handle(for requestID: UInt64, subscriberID: UUID)
+        -> ApplicationActivationHandle {
+        ApplicationActivationHandle { [weak self] in
+            let cancel: () -> Void = { [weak self] in
+                self?.cancelSubscriber(requestID: requestID, subscriberID: subscriberID)
+            }
+            if Thread.isMainThread { cancel() } else { DispatchQueue.main.async(execute: cancel) }
+        }
+    }
+
+    private func cancelSubscriber(requestID: UInt64, subscriberID: UUID) {
+        mainThreadOnly()
+        guard let request = current, request.id == requestID,
+              let completion = request.subscribers.removeValue(forKey: subscriberID) else { return }
+        if request.subscribers.isEmpty {
+            finish(request, with: .cancelled, keepFocusClaim: false)
+        }
+        deliver([completion], result: .cancelled)
+    }
+
+    private func finishCurrent(with result: ApplicationActivationResult) {
+        guard let request = current else { return }
+        finish(request, with: result, keepFocusClaim: false)
+    }
+
+    private func finish(_ request: Request,
+                        with result: ApplicationActivationResult,
+                        keepFocusClaim: Bool = true) {
+        guard current === request else { return }
+        current = nil
+        request.probeTask?.cancel()
+        request.settleTask?.cancel()
+        request.timeoutTask?.cancel()
+        // Release completed scheduling state on every exit. Timer closures
+        // also hold the request weakly if the coordinator is torn down early.
+        request.probeTask = nil
+        request.settleTask = nil
+        request.timeoutTask = nil
+        if let process = environment.application(request.bundleID, request.pid) {
+            relinquishVisibilityProtectionIfRevealed(request, process: process)
+            if request.visibilityGuard != nil, process.isHidden {
+                _ = environment.unhide(process.pid)
+            }
+        }
+        request.visibilityGuard?.finish()
+        finishLaunchReservation(request.id, result)
+
+        if keepFocusClaim, let pid = request.pid {
+            focusClaim = FocusClaim(
+                requestID: request.id,
+                pid: pid,
+                startedAt: request.startedAt,
+                expiresAt: environment.now() + 0.35
+            )
+        } else {
+            focusClaim = nil
+        }
+
+        let completions = Array(request.subscribers.values)
+        request.subscribers.removeAll()
+        deliver(completions, result: result)
+    }
+
+    private func deliver(_ completions: [(ApplicationActivationResult) -> Void],
+                         result: ApplicationActivationResult) {
+        guard !completions.isEmpty else { return }
+        // State transitions commit before client callbacks run. A callback
+        // may start another activation without orphaning its request.
+        _ = environment.schedule(0) { completions.forEach { $0(result) } }
     }
 }

--- a/HyprMac/Core/ApplicationLaunchVisibilityGuard.swift
+++ b/HyprMac/Core/ApplicationLaunchVisibilityGuard.swift
@@ -1,0 +1,208 @@
+// Independent, bounded cleanup for an application launched with `hides=true`.
+
+import AppKit
+import Foundation
+
+protocol ApplicationLaunchVisibilityProtecting: AnyObject {
+    func applicationOpened(pid: pid_t)
+    func finish()
+    func disarmAfterObservedReveal()
+}
+
+/// Small process boundary so cleanup can be tested without manipulating apps.
+protocol ApplicationLaunchVisibilityProcess: AnyObject {
+    var bundleIdentifier: String? { get }
+    var isTerminated: Bool { get }
+    var isHidden: Bool { get }
+    func unhide() -> Bool
+    func isSameProcess(as other: ApplicationLaunchVisibilityProcess) -> Bool
+}
+
+extension NSRunningApplication: ApplicationLaunchVisibilityProcess {
+    func isSameProcess(as other: ApplicationLaunchVisibilityProcess) -> Bool {
+        guard let other = other as? NSRunningApplication else { return false }
+        return isEqual(other)
+    }
+}
+
+/// Sends only public unhide requests; it never activates, minimizes, or hides.
+///
+/// The coordinator's main queue can be busy in synchronous AX calls. This
+/// small backstop therefore owns a separate serial queue and uses the public,
+/// thread-safe `NSRunningApplication` API, not off-main AX/AppKit view access.
+/// Apple documents that its changing properties are main-run-loop snapshots:
+/// a successful request is not proof of visibility, and this is best-effort
+/// cleanup, not a compositor guarantee or protection against process death.
+/// An already-sent OS request cannot be recalled atomically by disarming.
+///
+/// Once the coordinator has observed a reveal, disarming is irreversible so
+/// later Cmd-H is respected. A cancelled request with no PID remains eligible
+/// for its late Launch Services completion, without polling indefinitely.
+final class ApplicationLaunchVisibilityGuard: ApplicationLaunchVisibilityProtecting, @unchecked Sendable {
+    struct Environment {
+        // The inventory is read once at initialization and then on the
+        // guard's serial queue; injected implementations must be thread-safe.
+        var runningApplications: (String) -> [ApplicationLaunchVisibilityProcess]
+        var applicationForPID: (pid_t) -> ApplicationLaunchVisibilityProcess?
+
+        static let live = Environment(
+            runningApplications: { NSRunningApplication.runningApplications(withBundleIdentifier: $0) },
+            applicationForPID: { NSRunningApplication(processIdentifier: $0) }
+        )
+    }
+
+    private let bundleID: String
+    private let initialApplications: [ApplicationLaunchVisibilityProcess]
+    private let environment: Environment
+    private let queue: DispatchQueue
+    private let maximumAttempts: Int
+    private let retryInterval: TimeInterval
+    private let revealLock = NSLock()
+    private var observedReveal = false
+
+    // Everything below is accessed only on `queue`.
+    private var application: ApplicationLaunchVisibilityProcess?
+    private var cleanupRequested = false
+    private var terminal = false
+    private var attempts = 0
+    private var requestedUnhide = false
+    private var deadlineTask: DispatchWorkItem?
+    private var retryTask: DispatchWorkItem?
+
+    init(bundleID: String, timeout: TimeInterval,
+         environment: Environment = .live,
+         queue: DispatchQueue = DispatchQueue(label: "com.zachgray.HyprMac.launch-visibility", qos: .userInitiated),
+         maximumAttempts: Int = 8, retryInterval: TimeInterval = 0.15) {
+        self.bundleID = bundleID
+        self.environment = environment
+        self.queue = queue
+        self.maximumAttempts = max(1, maximumAttempts)
+        self.retryInterval = retryInterval.isFinite ? max(0.001, retryInterval) : 0.15
+        // Retain process identities, not just PIDs: a recycled PID must not
+        // make cleanup operate on an unrelated pre-existing application.
+        initialApplications = environment.runningApplications(bundleID)
+        let delay = timeout.isFinite ? max(0, timeout) : 0
+        let task = DispatchWorkItem { [self] in
+            deadlineTask = nil
+            // Early cancellation may have exhausted its discovery batch
+            // before the launch exists. Keep this independent deadline too.
+            if cleanupRequested, application == nil, !isDisarmed, !terminal {
+                attempts = 0
+                retryTask?.cancel()
+                retryTask = nil
+                attemptCleanup()
+            } else {
+                beginCleanup()
+            }
+        }
+        deadlineTask = task
+        queue.asyncAfter(deadline: .now() + delay, execute: task)
+    }
+
+    func applicationOpened(pid: pid_t) {
+        queue.async { [self] in
+            guard !isDisarmed, !terminal else { return }
+            guard let opened = environment.applicationForPID(pid),
+                  opened.bundleIdentifier == bundleID,
+                  !initialApplications.contains(where: { $0.isSameProcess(as: opened) }) else { return }
+            if let application, !application.isSameProcess(as: opened) { return }
+            let wasUnresolved = application == nil
+            application = opened
+            // A late callback gets a fresh bounded cleanup budget only when
+            // no process could be found during the previous attempt batch.
+            if cleanupRequested, wasUnresolved {
+                attempts = 0
+                retryTask?.cancel()
+                retryTask = nil
+                attemptCleanup()
+            }
+        }
+    }
+
+    /// End the controlled phase, including cancellation and supersession.
+    /// No foreground activation is performed when another user action won.
+    func finish() {
+        queue.async { [self] in
+            guard !isDisarmed, !terminal else { return }
+            beginCleanup()
+        }
+    }
+
+    /// The main coordinator supplies the authoritative successful-reveal
+    /// observation. Publish it synchronously before cancelling queued work.
+    func disarmAfterObservedReveal() {
+        revealLock.lock()
+        observedReveal = true
+        revealLock.unlock()
+        queue.async { [self] in stopTasks() }
+    }
+
+    private var isDisarmed: Bool {
+        revealLock.lock()
+        defer { revealLock.unlock() }
+        return observedReveal
+    }
+
+    private func beginCleanup() {
+        guard !isDisarmed, !terminal, !cleanupRequested else { return }
+        cleanupRequested = true
+        attemptCleanup()
+    }
+
+    private func attemptCleanup() {
+        guard !isDisarmed, !terminal else {
+            stopTasks()
+            return
+        }
+        attempts += 1
+        if application == nil {
+            let candidates = environment.runningApplications(bundleID)
+                .filter { candidate in
+                    !candidate.isTerminated
+                        && !initialApplications.contains(where: { $0.isSameProcess(as: candidate) })
+                }
+            // Do not guess between concurrent instances. The exact open
+            // completion can identify the intended process later.
+            if candidates.count == 1 { application = candidates[0] }
+        }
+
+        if let application {
+            if application.isTerminated {
+                terminal = true
+                stopTasks()
+                return
+            }
+            if requestedUnhide && !application.isHidden {
+                disarmAfterObservedReveal()
+                return
+            }
+            guard !isDisarmed else { return }
+            // NSRunningApplication is Sendable and documented thread-safe.
+            // `unhide` sends a request and does not grant foreground focus.
+            _ = application.unhide()
+            requestedUnhide = true
+        }
+
+        guard attempts < maximumAttempts else {
+            // With no process, retain only the ability to handle a late open
+            // callback. With a known process, stop rather than fighting a
+            // future manual hide after this bounded rescue window.
+            terminal = application != nil
+            retryTask = nil
+            return
+        }
+        let task = DispatchWorkItem { [self] in
+            retryTask = nil
+            attemptCleanup()
+        }
+        retryTask = task
+        queue.asyncAfter(deadline: .now() + retryInterval, execute: task)
+    }
+
+    private func stopTasks() {
+        deadlineTask?.cancel()
+        deadlineTask = nil
+        retryTask?.cancel()
+        retryTask = nil
+    }
+}

--- a/HyprMac/Core/HotkeyManager.swift
+++ b/HyprMac/Core/HotkeyManager.swift
@@ -34,6 +34,11 @@ class HotkeyManager {
     /// Fires for every recognized chord (Hypr + bound key).
     var onAction: ((Action) -> Void)?
 
+    /// Ordinary typing/Cmd-Tab supersedes pending app activation. Matched
+    /// chords dispatch through onAction instead, so a launch hotkey cannot
+    /// cancel the request it just started.
+    var onPassthroughKeyDown: ((TimeInterval) -> Void)?
+
     /// Fires when the Hypr key transitions from up to down.
     var onHyprKeyDown: (() -> Void)?
 
@@ -264,6 +269,10 @@ class HotkeyManager {
             return nil
         }
 
+        let eventTimestamp = TimeInterval(event.timestamp) / 1_000_000_000
+        DispatchQueue.main.async { [weak self] in
+            self?.onPassthroughKeyDown?(eventTimestamp)
+        }
         return event
     }
 

--- a/HyprMac/Core/Orchestration/ActionDispatcher.swift
+++ b/HyprMac/Core/Orchestration/ActionDispatcher.swift
@@ -40,7 +40,7 @@ final class ActionDispatcher {
     private let focusController: FocusStateController
     private let focusBorder: FocusBorder
     private let keybindOverlay: KeybindOverlayController
-    private let appLauncher: AppLauncherManager
+    private let appLauncher: ApplicationActivating
     private let workspaceOrchestrator: WorkspaceOrchestrator
     private let floatingController: FloatingWindowController
     private let config: UserConfig
@@ -67,7 +67,7 @@ final class ActionDispatcher {
          focusController: FocusStateController,
          focusBorder: FocusBorder,
          keybindOverlay: KeybindOverlayController,
-         appLauncher: AppLauncherManager,
+         appLauncher: ApplicationActivating,
          workspaceOrchestrator: WorkspaceOrchestrator,
          floatingController: FloatingWindowController,
          config: UserConfig) {
@@ -102,12 +102,18 @@ final class ActionDispatcher {
     /// - Parameter allWindows: the same window snapshot
     ///   `WindowDiscoveryService` consumed; passed through so
     ///   `animatedRetile` and workspace assignment do not re-query AX.
-    func applyChanges(_ changes: WindowChanges, allWindows: [HyprWindow]) {
+    func applyChanges(_ changes: WindowChanges, allWindows: [HyprWindow],
+                      workspaceOverrides: [CGWindowID: Int] = [:],
+                      performFocusUpdates: Bool = true) {
         // workspace assignment for new windows that didn't auto-float onto a
         // disabled monitor. assigning by physical screen — cursor-based was
         // unreliable under multi-monitor + display-reconfig churn.
         for w in changes.newWindows where !changes.newOnDisabledMonitor.contains(w.windowID) {
-            assignNewWindow(w)
+            if let workspace = workspaceOverrides[w.windowID] {
+                workspaceManager.assignWindow(w.windowID, toWorkspace: workspace)
+            } else {
+                assignNewWindow(w)
+            }
         }
 
         // engine/workspace/focus cleanup for ids the service forgot.
@@ -143,6 +149,9 @@ final class ActionDispatcher {
             // animate surrounding windows sliding to fill gaps / make room.
             animatedRetile(allWindows)
         }
+
+        // A controlled reveal prepares geometry before transferring focus.
+        guard performFocusUpdates else { return }
 
         // if the FFM-tracked window disappeared, refocus to whatever tiled window
         // is under the cursor now. without this, focus gets stuck because
@@ -182,7 +191,18 @@ final class ActionDispatcher {
         case .showKeybinds:
             keybindOverlay.toggle(keybinds: config.keybinds)
         case .launchApp(let bundleID):
-            appLauncher.launchOrFocus(bundleID: bundleID)
+            appLauncher.activate(bundleID: bundleID, source: .hotkey) { result in
+                switch result {
+                case .failed(let message):
+                    hyprLog(.notice, .lifecycle, "app activation failed for \(bundleID): \(message)")
+                case .timedOut:
+                    hyprLog(.notice, .lifecycle, "app activation timed out for \(bundleID) — failed open")
+                case .unavailable:
+                    hyprLog(.notice, .lifecycle, "app activation unavailable for \(bundleID)")
+                case .activated, .openedWithoutWindow, .cancelled:
+                    break
+                }
+            }
         case .focusMenuBar:
             warpToMenuBar()
         case .focusFloating:

--- a/HyprMac/Core/ScratchpadController.swift
+++ b/HyprMac/Core/ScratchpadController.swift
@@ -122,10 +122,14 @@ final class ScratchpadController {
         if isVisible { hide(reason: .toggle) } else { show() }
     }
 
-    func show(focusing preferredID: CGWindowID? = nil) {
-        if isVisible {
+    func show(
+        focusing preferredID: CGWindowID? = nil,
+        focusReassertionAllowed: @escaping () -> Bool = { true }
+    ) {
+        let preferredAlreadySummoned = preferredID.map { isSummoned($0) } ?? true
+        if isVisible, preferredAlreadySummoned {
             if let preferredID, let w = stateCache.cachedWindows[preferredID] {
-                w.focus()
+                w.focus(reassertIf: focusReassertionAllowed)
                 noteFocus(preferredID)
                 focusController.recordFocus(preferredID, reason: "scratchpad-refocus")
             }
@@ -140,7 +144,7 @@ final class ScratchpadController {
         suppressions.suppress("workspace-transition", for: 1.5)
         suppressions.suppress("activation-switch", for: 0.5)
         suppressions.suppress("mouse-focus", for: 0.15)
-        focusBeforeShow = focusController.lastFocusedID
+        if !isVisible { focusBeforeShow = focusController.lastFocusedID }
         shownAt = Date()
         workspaceManager.scratchpadVisible = true
 
@@ -232,7 +236,7 @@ final class ScratchpadController {
         }
 
         if let headID = mruOrder.first, let head = windowsByID[headID] {
-            head.focus()
+            head.focus(reassertIf: focusReassertionAllowed)
             focusController.recordFocus(headID, reason: "scratchpad-show")
             updateFocusBorder(head)
         }

--- a/HyprMac/Core/WindowManager.swift
+++ b/HyprMac/Core/WindowManager.swift
@@ -30,7 +30,7 @@ class WindowManager {
     let spaceManager = SpaceManager()
     let displayManager = DisplayManager()
     let cursorManager = CursorManager()
-    let appLauncher = AppLauncherManager()
+    let activationCoordinator: ApplicationActivationCoordinator
     let config: UserConfig
     let focusBorder = FocusBorder()
     let focusBrackets = FocusBrackets()
@@ -80,6 +80,8 @@ class WindowManager {
     // mouse tracking
     private var mouseMoveMonitor: Any?
     private var mouseDownMonitor: Any?
+    private var otherMouseDownMonitor: Any?
+    private var localInputMonitor: Any?
     private var mouseUpMonitor: Any?
     private var mouseDragMonitor: Any?
     private var mouseButtonDown = false
@@ -135,6 +137,30 @@ class WindowManager {
     // live config reload
     private var configObservers: Set<AnyCancellable> = []
     private var isRunning = false
+    private var hasInitialSnapshot = false
+
+    private final class LaunchReservation {
+        let requestID: UInt64
+        let bundleID: String
+        let workspace: Int
+        let displayFingerprint: String
+        let reservedFrame: CGRect
+        let changedSiblings: [(HyprWindow, CGRect)]
+        let startedAt = ProcessInfo.processInfo.systemUptime
+        var verificationTask: DispatchWorkItem?
+
+        init(requestID: UInt64, bundleID: String, workspace: Int,
+             displayFingerprint: String, reservedFrame: CGRect,
+             changedSiblings: [(HyprWindow, CGRect)]) {
+            self.requestID = requestID
+            self.bundleID = bundleID
+            self.workspace = workspace
+            self.displayFingerprint = displayFingerprint
+            self.reservedFrame = reservedFrame
+            self.changedSiblings = changedSiblings
+        }
+    }
+    private var launchReservation: LaunchReservation?
 
     // fingerprint of the last display layout we acted on. macOS posts
     // didChangeScreenParametersNotification for things that don't actually
@@ -168,6 +194,7 @@ class WindowManager {
     init(config: UserConfig) {
         self.config = config
         self.focusController = FocusStateController(focusBorder: focusBorder)
+        self.activationCoordinator = ApplicationActivationCoordinator(accessibility: accessibility)
         self.workspaceManager = WorkspaceManager(displayManager: displayManager)
         self.tilingEngine = TilingEngine(displayManager: displayManager)
         self.discovery = WindowDiscoveryService(
@@ -233,8 +260,37 @@ class WindowManager {
         scratchpad.lowerScrimBelow = { [weak self] wid in
             self?.dimmingOverlay.orderBelow(windowNumber: Int(wid))
         }
+
+        // Hotkeys and Spotlight converge here. The coordinator owns request
+        // ordering; these callbacks keep workspace/discovery ownership in the
+        // existing services instead of duplicating tiling policy.
+        activationCoordinator.prepareWindowsForReveal = { [weak self] pid, ids, selectedID in
+            self?.prepareApplicationWindowsForReveal(
+                pid: pid, windowIDs: ids, selectedWindowID: selectedID
+            ) ?? false
+        }
+        activationCoordinator.routeWindow = { [weak self] pid, id, requestID in
+            self?.routeActivatedWindow(pid: pid, windowID: id, requestID: requestID) ?? false
+        }
+        activationCoordinator.lastFocusedWindowID = { [weak self] in
+            self?.focusController.lastFocusedID ?? 0
+        }
+        activationCoordinator.isAvailable = { [weak self] in
+            self?.isRunning == true && self?.hasInitialSnapshot == true && AXIsProcessTrusted()
+        }
+        activationCoordinator.reserveSpaceBeforeLaunch = { [weak self] bundleID, requestID, completion in
+            guard let self else { completion(); return }
+            self.reserveApplicationSpace(bundleID: bundleID, requestID: requestID, completion: completion)
+        }
+        activationCoordinator.finishLaunchReservation = { [weak self] requestID, result in
+            self?.finishApplicationReservation(requestID: requestID, result: result)
+        }
+
         self.pollingScheduler = PollingScheduler { [weak self] in
             self?.pollWindowChanges()
+        }
+        activationCoordinator.requestDiscovery = { [weak self] delay in
+            self?.pollingScheduler.schedule(after: delay)
         }
         // hold polling off while a cross-monitor drag-swap is in flight (Phase 4 step 5).
         // DragSwapHandler.applySwap registers the "cross-swap-in-flight" key for ~800ms;
@@ -246,6 +302,7 @@ class WindowManager {
         pollingScheduler.isSuppressed = { [weak self] in
             guard let self else { return false }
             return self.mouseButtonDown
+                || self.suppressions.isSuppressed("activation-reservation")
                 || self.suppressions.isSuppressed("cross-swap-in-flight")
                 || self.suppressions.isSuppressed("workspace-transition")
         }
@@ -253,6 +310,9 @@ class WindowManager {
         hotkeyManager.onAction = { [weak self] action in
             self?.suppressions.suppress("mouse-focus", for: 0.15)
             self?.handleAction(action)
+        }
+        hotkeyManager.onPassthroughKeyDown = { [weak self] timestamp in
+            self?.activationCoordinator.cancelForUserOverride(eventTimestamp: timestamp)
         }
 
         hotkeyManager.onHyprKeyDown = { [weak self] in
@@ -333,7 +393,7 @@ class WindowManager {
             focusController: focusController,
             focusBorder: focusBorder,
             keybindOverlay: keybindOverlay,
-            appLauncher: appLauncher,
+            appLauncher: activationCoordinator,
             workspaceOrchestrator: workspaceOrchestrator,
             floatingController: floatingController,
             config: config
@@ -401,6 +461,11 @@ class WindowManager {
     func start() {
         guard !isRunning else { return }
         isRunning = true
+        if #available(macOS 15.0, *) {
+            MainActor.assumeIsolated {
+                AppIntentApplicationActivationBridge.install(activationCoordinator, ready: false)
+            }
+        }
 
         // route AX notifications into the coalescing scheduler. these are the
         // primary discovery triggers; the scheduler's timer is a safety net.
@@ -408,8 +473,9 @@ class WindowManager {
         // so no extra guards here. create/miniaturize/deminiaturize get a 0.2s
         // debounce to let AX settle; focus is snappier at 0.15s; destroy uses
         // the 0.2s default.
-        axNotifications.onEvent = { [weak self] kind, _ in
+        axNotifications.onEvent = { [weak self] kind, pid in
             guard let self else { return }
+            self.activationCoordinator.noteAXEvent(pid: pid)
             switch kind {
             case .windowDestroyed:
                 self.pollingScheduler.schedule()
@@ -443,6 +509,12 @@ class WindowManager {
             // screen-parameters notification after launch is a no-op.
             self.lastDisplayFingerprint = self.displayFingerprint()
             self.snapshotAndTile()
+            self.hasInitialSnapshot = true
+            if #available(macOS 15.0, *) {
+                MainActor.assumeIsolated {
+                    AppIntentApplicationActivationBridge.markReady(self.activationCoordinator)
+                }
+            }
             // attach AX observers after the initial tile so their events feed
             // the same coalescing scheduler. this covers the app-level
             // subscriptions (create / focus); window-level ones (destroy /
@@ -532,6 +604,7 @@ class WindowManager {
             .removeDuplicates()
             .sink { [weak self] newGap in
                 guard let self = self else { return }
+                self.activationCoordinator.cancelForUserOverride()
                 self.tilingEngine.gapSize = newGap
                 self.animatedRetile()
             }.store(in: &configObservers)
@@ -541,6 +614,7 @@ class WindowManager {
             .removeDuplicates()
             .sink { [weak self] newPadding in
                 guard let self = self else { return }
+                self.activationCoordinator.cancelForUserOverride()
                 self.tilingEngine.outerPadding = newPadding
                 self.animatedRetile()
             }.store(in: &configObservers)
@@ -550,6 +624,7 @@ class WindowManager {
             .removeDuplicates()
             .sink { [weak self] newSplits in
                 guard let self = self else { return }
+                self.activationCoordinator.cancelForUserOverride()
                 self.tilingEngine.maxSplitsPerMonitor = newSplits
                 self.snapshotAndTile()
                 hyprLog(.debug, .lifecycle, "max splits updated: \(newSplits)")
@@ -560,6 +635,7 @@ class WindowManager {
             .removeDuplicates()
             .sink { [weak self] newDisabled in
                 guard let self = self else { return }
+                self.activationCoordinator.cancelForUserOverride()
                 self.workspaceManager.disabledMonitors = newDisabled
                 // unfloat windows on newly-disabled monitors from their tiling trees
                 self.handleDisabledMonitorChange()
@@ -658,8 +734,15 @@ class WindowManager {
     /// the polling scheduler, removes mouse monitors, halts the hotkey tap,
     /// and hides every focus indicator. Safe to call when not running.
     func stop() {
-        restoreAllWindows()
         isRunning = false
+        hasInitialSnapshot = false
+        activationCoordinator.stop()
+        if #available(macOS 15.0, *) {
+            MainActor.assumeIsolated {
+                AppIntentApplicationActivationBridge.remove(activationCoordinator)
+            }
+        }
+        restoreAllWindows()
         axNotifications.detachAll()
         pollingScheduler.stop()
         stopMouseTracking()
@@ -710,6 +793,7 @@ class WindowManager {
     /// (app menu, status item, context menu) opens. Suppresses FFM so the
     /// user can scrub through menu items without focus jumping behind.
     @objc private func menuTrackingBegan(_ note: Notification) {
+        activationCoordinator.cancelForUserOverride()
         mouseTracker.menuTrackingBegan()
     }
 
@@ -737,11 +821,24 @@ class WindowManager {
     /// discovery poll and would otherwise lag the live drag at 60Hz; mouseUp restores
     /// it after a short settle delay.
     private func startMouseTracking() {
+        otherMouseDownMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.rightMouseDown, .otherMouseDown]
+        ) { [weak self] event in
+            self?.activationCoordinator.cancelForUserOverride(eventTimestamp: event.timestamp)
+        }
+        // Global monitors exclude HyprMac's own Settings/menu windows.
+        localInputMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+        ) { [weak self] event in
+            self?.activationCoordinator.cancelForUserOverride(eventTimestamp: event.timestamp)
+            return event
+        }
         mouseMoveMonitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { [weak self] _ in
             self?.mouseTracker.handleMouseMove()
         }
         mouseDownMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDown) { [weak self] event in
             guard let self else { return }
+            self.activationCoordinator.cancelForUserOverride(eventTimestamp: event.timestamp)
             self.mouseButtonDown = true
             self.mouseDraggedSinceDown = false
             // the event carries the exact click location. sampling
@@ -837,10 +934,14 @@ class WindowManager {
     private func stopMouseTracking() {
         if let m = mouseMoveMonitor { NSEvent.removeMonitor(m) }
         if let m = mouseDownMonitor { NSEvent.removeMonitor(m) }
+        if let m = otherMouseDownMonitor { NSEvent.removeMonitor(m) }
+        if let m = localInputMonitor { NSEvent.removeMonitor(m) }
         if let m = mouseDragMonitor { NSEvent.removeMonitor(m) }
         if let m = mouseUpMonitor { NSEvent.removeMonitor(m) }
         mouseMoveMonitor = nil
         mouseDownMonitor = nil
+        otherMouseDownMonitor = nil
+        localInputMonitor = nil
         mouseDragMonitor = nil
         mouseUpMonitor = nil
         mouseDownTiledFrames.removeAll()
@@ -1206,6 +1307,12 @@ class WindowManager {
     /// callback site stays terse and so subclasses or tests can intercept
     /// in one place. Also called from the menu bar (cheat-sheet row).
     func handleAction(_ action: Action) {
+        if case .launchApp = action {
+            // Repeated requests for the same app are coalesced by the
+            // coordinator; a different app supersedes the prior request.
+        } else {
+            activationCoordinator.cancelForUserOverride()
+        }
         // workspace flows park/unpark and then focus+warp. mid-display-
         // transition the tile pass is deferred, so the target workspace
         // would stay parked with the cursor warped to the 1px park sliver.
@@ -2124,6 +2231,282 @@ class WindowManager {
         return result
     }
 
+    // MARK: - application activation
+
+    /// Preflow one speculative tile before starting the app. This touches
+    /// only siblings whose planned frame changes, not every desktop window.
+    /// No placeholder enters the BSP tree or persistent configuration.
+    private func reserveApplicationSpace(bundleID: String, requestID: UInt64,
+                                         completion: @escaping () -> Void) {
+        guard isRunning, hasInitialSnapshot, !displayTransitionPending, !mouseButtonDown,
+              !config.excludedBundleIDs.contains(bundleID) else { completion(); return }
+        let screen = screenUnderCursor()
+        guard !workspaceManager.isMonitorDisabled(screen) else { completion(); return }
+        let workspace = workspaceManager.workspaceForScreen(screen)
+        guard let plan = tilingEngine.planApplicationLaunch(
+            onWorkspace: workspace, screen: screen,
+            estimatedMinimumSize: HyprWindow.estimatedMinimumSize(for: bundleID)
+        ) else {
+            hyprLog(.debug, .lifecycle, "launch reservation: no safe predicted slot for \(bundleID)")
+            completion()
+            return
+        }
+
+        let changed = plan.siblingLayouts.filter { window, target in
+            !activationFrameMatches(window.cachedFrame ?? window.frame, target)
+        }
+        guard changed.allSatisfy({ accessibility.canSetFrame(of: $0.0) }) else {
+            completion()
+            return
+        }
+        let reservation = LaunchReservation(
+            requestID: requestID, bundleID: bundleID, workspace: workspace,
+            displayFingerprint: displayFingerprint(), reservedFrame: plan.reservedFrame,
+            changedSiblings: changed
+        )
+        launchReservation = reservation
+        // Normal discovery must not immediately fill our deliberately empty
+        // gap. AX events still reach the coordinator; its preparation pass
+        // explicitly includes the real hidden window before releasing this.
+        suppressions.suppress("activation-reservation", for: 3.0)
+        for (window, frame) in changed { window.setFrame(frame, crossMonitor: false) }
+        verifyApplicationReservation(reservation, completion: completion)
+    }
+
+    private func verifyApplicationReservation(_ reservation: LaunchReservation,
+                                              completion: @escaping () -> Void) {
+        guard launchReservation === reservation else { return }
+        let task = DispatchWorkItem { [weak self] in
+            guard let self, self.launchReservation === reservation else { return }
+            let accepted = reservation.changedSiblings.allSatisfy {
+                self.activationFrameMatches($0.0.frame, $0.1)
+            }
+            if accepted {
+                reservation.verificationTask = nil
+                hyprLog(.debug, .lifecycle, "launch reservation: \(reservation.changedSiblings.count) sibling(s) ready before app start")
+                completion()
+            } else if ProcessInfo.processInfo.systemUptime - reservation.startedAt < 0.35 {
+                self.verifyApplicationReservation(reservation, completion: completion)
+            } else {
+                // A reluctant sibling must not block launching an app. Give
+                // back the gap and use the normal controlled-launch fallback.
+                hyprLog(.notice, .lifecycle, "launch reservation: sibling readback did not settle — reverting speculative gap")
+                self.finishApplicationReservation(requestID: reservation.requestID,
+                                                  result: .openedWithoutWindow)
+                completion()
+            }
+        }
+        reservation.verificationTask = task
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.04, execute: task)
+    }
+
+    private func finishApplicationReservation(requestID: UInt64,
+                                              result: ApplicationActivationResult) {
+        guard let reservation = launchReservation, reservation.requestID == requestID else { return }
+        reservation.verificationTask?.cancel()
+        reservation.verificationTask = nil
+        launchReservation = nil
+        suppressions.clear("activation-reservation")
+        guard isRunning else { return }
+        if case .activated = result {
+            // The real window already owns the gap and has been laid out.
+        } else {
+            // Reflow current live state, not saved frames/topology that may
+            // now conflict with a user action or a display reconfiguration.
+            tileAllVisibleSpaces()
+        }
+        pollingScheduler.schedule(after: 0.06)
+    }
+
+    private func activationFrameMatches(_ actual: CGRect?, _ expected: CGRect) -> Bool {
+        guard let actual else { return false }
+        return abs(actual.minX - expected.minX) <= 4
+            && abs(actual.minY - expected.minY) <= 4
+            && abs(actual.width - expected.width) <= TilingConfig.frameToleranceXPx
+            && abs(actual.height - expected.height) <= TilingConfig.frameToleranceXPx
+    }
+
+    /// Feed hidden/minimized windows through the same discovery and tiling
+    /// pipeline used for ordinary AX events. This is the controlled-reveal
+    /// seam: no parallel workspace or BSP bookkeeping is introduced.
+    private func prepareApplicationWindowsForReveal(
+        pid: pid_t,
+        windowIDs: Set<CGWindowID>,
+        selectedWindowID: CGWindowID
+    ) -> Bool {
+        guard isRunning, !displayTransitionPending, !mouseButtonDown,
+              !windowIDs.isEmpty else { return false }
+
+        let activationWindows = accessibility.activationWindows(
+            for: pid, matching: windowIDs
+        )
+        guard Set(activationWindows.map(\.windowID)) == windowIDs,
+              activationWindows.allSatisfy(accessibility.canSetFrame(of:)) else {
+            hyprLog(.notice, .lifecycle, "controlled reveal: AX could not safely address every target window — failing open")
+            return false
+        }
+        // The scratchpad owns its separate region and stacking sequence.
+        // Restore through that existing path instead of inventing a second
+        // hidden-layer layout policy here.
+        if workspaceManager.workspaceFor(selectedWindowID) == ScratchpadController.workspace {
+            return false
+        }
+
+        let reservation = launchReservation.flatMap { candidate -> LaunchReservation? in
+            guard candidate.bundleID == NSRunningApplication(processIdentifier: pid)?.bundleIdentifier,
+                  candidate.displayFingerprint == displayFingerprint(),
+                  workspaceManager.isWorkspaceVisible(candidate.workspace) else { return nil }
+            return candidate
+        }
+        if let reservation,
+           workspaceManager.workspaceFor(selectedWindowID) == nil,
+           let selected = activationWindows.first(where: { $0.windowID == selectedWindowID }) {
+            // The reservation's screen/workspace is authoritative for this
+            // controlled cold launch, not the app's remembered old position.
+            selected.setFrame(reservation.reservedFrame)
+        }
+
+        // Prefer the activation copy for duplicate IDs: it remains usable
+        // while the app is hidden/minimized, whereas the on-screen snapshot
+        // can carry a just-stale element from the prior discovery pass.
+        var windowsByID = Dictionary(accessibility.getAllWindows().map { ($0.windowID, $0) },
+                                     uniquingKeysWith: { _, latest in latest })
+        for window in activationWindows { windowsByID[window.windowID] = window }
+        let combined = windowsByID.values.sorted { $0.windowID < $1.windowID }
+
+        // Switch ownership first. A returned window's BSP leaf may have
+        // been removed while minimized, so only the now-visible workspace
+        // can reinsert and lay it out before the OS reveal.
+        if let workspace = workspaceManager.workspaceFor(selectedWindowID),
+           !workspaceManager.isWorkspaceVisible(workspace) {
+            if scratchpad.isVisible { scratchpad.hide(reason: .activationChange) }
+            guard workspaceOrchestrator.prepareWorkspaceForReveal(workspace, windows: combined) else {
+                return false
+            }
+        }
+
+        axNotifications.ensureWindowSubscriptions(for: combined)
+        tilingEngine.primeMinimumSizes(combined)
+        let runningPIDs = Set(NSWorkspace.shared.runningApplications.map { $0.processIdentifier })
+        let changes = discovery.computeChanges(
+            snapshot: combined,
+            runningPIDs: runningPIDs,
+            excludedBundleIDs: Set(config.excludedBundleIDs),
+            focusedWindowID: focusController.lastFocusedID
+        )
+        var workspaceOverrides: [CGWindowID: Int] = [:]
+        if let reservation {
+            for window in changes.newWindows where window.ownerPID == pid {
+                workspaceOverrides[window.windowID] = reservation.workspace
+            }
+        }
+        actionDispatcher.applyChanges(changes, allWindows: combined,
+                                      workspaceOverrides: workspaceOverrides,
+                                      performFocusUpdates: false)
+
+        // A window can already be lifecycle-known if Cmd-H and this trigger
+        // race the next poll. Ensure that no-op discovery case still lays it
+        // out before reveal.
+        if !changes.needsRetile {
+            tileAllVisibleSpaces(windows: combined)
+        }
+        repairParkedWindows(combined)
+
+        let intended = tilingEngine.intendedTileRects()
+        let originTolerance: CGFloat = 4
+        let sizeTolerance = TilingConfig.frameToleranceXPx
+
+        for window in activationWindows {
+            if let workspace = workspaceManager.workspaceFor(window.windowID),
+               !workspaceManager.isWorkspaceVisible(workspace) {
+                // Unhiding an app reveals all of its windows. Its unselected
+                // windows on other Hypr workspaces must remain parked.
+                guard let actual = window.position else { return false }
+                let parked = workspaceManager.hidePosition()
+                guard abs(actual.x - parked.x) <= originTolerance,
+                      abs(actual.y - parked.y) <= originTolerance else { return false }
+                continue
+            }
+            if stateCache.floatingWindowIDs.contains(window.windowID) {
+                continue
+            }
+            guard let expected = intended[window.windowID] else {
+                hyprLog(.notice, .lifecycle, "controlled reveal: no intended frame for \(window.windowID) — failing open")
+                return false
+            }
+
+            let actual = window.frame ?? .zero
+
+            let frameMatches = abs(actual.minX - expected.minX) <= originTolerance
+                && abs(actual.minY - expected.minY) <= originTolerance
+                && abs(actual.width - expected.width) <= sizeTolerance
+                && abs(actual.height - expected.height) <= sizeTolerance
+            guard frameMatches else {
+                hyprLog(.notice, .lifecycle, "controlled reveal: frame verification failed for \(window.windowID) — failing open")
+                return false
+            }
+        }
+
+        hyprLog(.debug, .lifecycle, "controlled reveal: prepared \(activationWindows.count) window(s) for pid=\(pid)")
+        return true
+    }
+
+    /// Focus the exact candidate selected by the activation coordinator.
+    /// Returning false asks the coordinator to wait for the next discovery
+    /// pass rather than guessing from stale workspace state.
+    private func routeActivatedWindow(
+        pid: pid_t,
+        windowID: CGWindowID,
+        requestID: UInt64
+    ) -> Bool {
+        guard isRunning, !displayTransitionPending else { return false }
+
+        guard let window = accessibility.visibleActivationWindow(
+            for: pid, windowID: windowID
+        ) else { return false }
+        if workspaceManager.workspaceFor(windowID) == nil {
+            // A just-opened window is not ready until normal discovery has
+            // assigned and tiled it. Disabled monitors intentionally have
+            // no workspace ownership and remain ordinary floating windows.
+            guard let screen = displayManager.screen(for: window),
+                  workspaceManager.isMonitorDisabled(screen) else { return false }
+        }
+
+        let focusGuard = { [weak self] in
+            self?.activationCoordinator.allowsFocusReassertion(for: requestID) ?? false
+        }
+        suppressions.suppress("activation-switch", for: 0.5)
+        suppressions.suppress("mouse-focus", for: 0.15)
+
+        if workspaceManager.workspaceFor(windowID) == ScratchpadController.workspace {
+            scratchpad.show(
+                focusing: windowID,
+                focusReassertionAllowed: focusGuard
+            )
+            return scratchpad.isVisible && scratchpad.isSummoned(windowID)
+        }
+
+        if scratchpad.isVisible {
+            scratchpad.hide(reason: .activationChange)
+        }
+
+        if let workspace = workspaceManager.workspaceFor(windowID),
+           !workspaceManager.isWorkspaceVisible(workspace) {
+            workspaceOrchestrator.switchWorkspace(
+                workspace,
+                preferredWindowID: windowID,
+                preferredWindow: window,
+                focusReassertionAllowed: focusGuard
+            )
+            return true
+        }
+
+        window.focus(reassertIf: focusGuard)
+        focusController.recordFocus(windowID, reason: "application-activation")
+        updateFocusBorder(for: window)
+        return true
+    }
+
     // MARK: - poll
 
     /// Run a single discovery diff and hand the result to the dispatcher's
@@ -2158,6 +2541,7 @@ class WindowManager {
         )
         actionDispatcher.applyChanges(changes, allWindows: allWindows)
         repairParkedWindows(allWindows)
+        activationCoordinator.noteDiscoveryCompleted()
     }
 
     /// Park self-repair: a hidden-workspace window the OS (or its own app)
@@ -2215,6 +2599,25 @@ class WindowManager {
                     self.mouseTracker.dockIsActive = false
                 }
             }
+        }
+
+        // A request-correlated activation must not fall through to the Dock
+        // affordance below: that path can inspect an older parked window and
+        // switch to the wrong workspace before the requested window is
+        // discovered. A foreign activation
+        // cancels the request and continues through the normal user path.
+        if let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
+           activationCoordinator.noteApplicationActivated(
+               bundleID: app.bundleIdentifier,
+               pid: app.processIdentifier
+           ) == .claimed {
+            pollingScheduler.schedule()
+            if !stateCache.floatingWindowIDs.isEmpty {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+                    self?.floatingController.raiseBehind()
+                }
+            }
+            return
         }
 
         // scratchpad: an activation outside the layer dismisses it (Cmd-Tab,
@@ -2306,6 +2709,7 @@ class WindowManager {
     /// Hypr modifier (the "sticky Caps Lock" bug from a different angle).
     @objc private func systemInterruption(_ notification: Notification) {
         hyprLog(.notice, .hotkey, "system interruption (\(notification.name.rawValue)) — resetting hotkey state")
+        activationCoordinator.cancelForUserOverride()
         hotkeyManager.resetTrackingAfterTapInterruption()
         // also clear stuck dock flag and menu-tracking flag — sleep dialogs
         // and screen lock can leave either stale.
@@ -2332,6 +2736,10 @@ class WindowManager {
             // wire up event-driven discovery for the new app. attach is
             // idempotent and retries once if the app isn't AX-ready yet.
             axNotifications.attach(pid: app.processIdentifier)
+            activationCoordinator.noteApplicationLaunched(
+                bundleID: app.bundleIdentifier,
+                pid: app.processIdentifier
+            )
         }
         pollingScheduler.schedule(after: 0.5)
     }
@@ -2342,6 +2750,10 @@ class WindowManager {
     /// path can only see windows still in `knownWindowIDs`.
     @objc private func appDidTerminate(_ notification: Notification) {
         if let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication {
+            activationCoordinator.noteApplicationTerminated(
+                bundleID: app.bundleIdentifier,
+                pid: app.processIdentifier
+            )
             axNotifications.detach(pid: app.processIdentifier)
             forgetApp(app.processIdentifier)
         }
@@ -2351,6 +2763,9 @@ class WindowManager {
     /// React to an app being hidden or unhidden (Cmd-H, Hide Others, etc.).
     /// Short delay lets AX settle before discovery picks up the change.
     @objc private func appVisibilityChanged(_ notification: Notification) {
+        if let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication {
+            activationCoordinator.noteAXEvent(pid: app.processIdentifier)
+        }
         pollingScheduler.schedule(after: 0.3)
     }
 
@@ -2376,6 +2791,10 @@ class WindowManager {
             hyprLog(.debug, .lifecycle, "screenParametersChanged: fingerprint unchanged — ignoring spurious fire")
             return
         }
+        // Cancellation can roll back a speculative launch layout. Defer
+        // that tiling until monitor/workspace reconciliation finishes too.
+        displayTransitionPending = true
+        activationCoordinator.cancelForUserOverride()
         let names = displayManager.screens.map { $0.localizedName }.joined(separator: ", ")
         hyprLog(.notice, .lifecycle, "screenParametersChanged fired (current screens: [\(names)])")
         // the scratchpad can't survive a topology change — reconcile would
@@ -2386,7 +2805,6 @@ class WindowManager {
         // OS-shuffled positions and drift-reassigns them to whatever
         // workspace happens to own the screen they got dumped on.
         suppressions.suppress("workspace-transition", for: 3.0)
-        displayTransitionPending = true
         displayChangeGeneration += 1
         scheduleDisplayReconcile()
     }
@@ -2449,6 +2867,7 @@ class WindowManager {
     /// Handler for the `.hyprMacRetileAll` notification posted from the
     /// menu bar's "Retile All" action.
     @objc private func retileAllRequested() {
+        activationCoordinator.cancelForUserOverride()
         hyprLog(.debug, .lifecycle, "retile all spaces requested")
         scratchpad.hide(reason: .workspaceAction)
         snapshotAndTile()

--- a/HyprMac/Core/Workspace/WorkspaceOrchestrator.swift
+++ b/HyprMac/Core/Workspace/WorkspaceOrchestrator.swift
@@ -72,7 +72,12 @@ final class WorkspaceOrchestrator {
     /// Suppresses `activation-switch` and `mouse-focus` for the duration
     /// (and a tail) of the switch — `best.focus()` queues asynchronous
     /// notifications that would otherwise re-bounce focus.
-    func switchWorkspace(_ number: Int) {
+    func switchWorkspace(
+        _ number: Int,
+        preferredWindowID: CGWindowID? = nil,
+        preferredWindow: HyprWindow? = nil,
+        focusReassertionAllowed: @escaping () -> Bool = { true }
+    ) {
         // hold polls off for the duration of the transition. Tahoe AX
         // writes lag, so a poll mid-transition reads stale frames and
         // drift detection can falsely reassign windows.
@@ -88,9 +93,13 @@ final class WorkspaceOrchestrator {
         if result.alreadyVisible {
             // workspace is showing on result.screen — just focus it
             let visibleWindows = allWindows.filter { result.toShow.contains($0.windowID) }
-            if let best = visibleWindows.first(where: { !stateCache.floatingWindowIDs.contains($0.windowID) })
+            if let best = resolvedPreferredWindow(in: visibleWindows,
+                                                  resultIDs: result.toShow,
+                                                  preferredID: preferredWindowID,
+                                                  fallback: preferredWindow)
+                ?? visibleWindows.first(where: { !stateCache.floatingWindowIDs.contains($0.windowID) })
                 ?? visibleWindows.first {
-                best.focus()
+                best.focus(reassertIf: focusReassertionAllowed)
                 cursorManager.warpToCenter(of: best)
                 focusController.recordFocus(best.windowID, reason: "switchWorkspace-already-visible")
                 updateFocusBorder(best)
@@ -102,18 +111,7 @@ final class WorkspaceOrchestrator {
             return
         }
 
-        // batch: hide old + restore floating new in one tight pass
-        for wid in result.toHide {
-            if let w = allWindows.first(where: { $0.windowID == wid }) ?? stateCache.cachedWindows[wid] {
-                if stateCache.floatingWindowIDs.contains(wid) { workspaceManager.saveFloatingFrame(w) }
-                workspaceManager.hideInCorner(w, on: result.screen)
-            }
-        }
-        for wid in result.toShow where stateCache.floatingWindowIDs.contains(wid) {
-            if let w = allWindows.first(where: { $0.windowID == wid }) ?? stateCache.cachedWindows[wid] {
-                workspaceManager.restoreFloatingFrame(w)
-            }
-        }
+        applyWorkspaceVisibility(result, windows: allWindows)
 
         // retile immediately — no delay between hide and show
         tileAllVisibleSpaces()
@@ -122,8 +120,12 @@ final class WorkspaceOrchestrator {
         // any floating window before giving up. only warp+hide if truly empty.
         let newWorkspaceWindows = allWindows.filter { result.toShow.contains($0.windowID) }
         let tiled = newWorkspaceWindows.first { !stateCache.floatingWindowIDs.contains($0.windowID) }
-        if let best = tiled ?? newWorkspaceWindows.first {
-            best.focus()
+        if let best = resolvedPreferredWindow(in: newWorkspaceWindows,
+                                              resultIDs: result.toShow,
+                                              preferredID: preferredWindowID,
+                                              fallback: preferredWindow)
+            ?? tiled ?? newWorkspaceWindows.first {
+            best.focus(reassertIf: focusReassertionAllowed)
             cursorManager.warpToCenter(of: best)
             focusController.recordFocus(best.windowID, reason: "switchWorkspace-after-show")
             updateFocusBorder(best)
@@ -134,6 +136,50 @@ final class WorkspaceOrchestrator {
         }
 
         NotificationCenter.default.post(name: .hyprMacWorkspaceChanged, object: nil)
+    }
+
+    /// Change workspace visibility without activating or focusing a window.
+    /// The caller supplies hidden/minimized AX candidates and immediately
+    /// tiles that snapshot before asking macOS to reveal the selected app.
+    @discardableResult
+    func prepareWorkspaceForReveal(_ number: Int, windows: [HyprWindow]) -> Bool {
+        guard workspaceManager.homeScreenForWorkspace(number) != nil else { return false }
+        suppressions.suppress("workspace-transition", for: 1.5)
+        suppressions.suppress("activation-switch", for: 0.5)
+        suppressions.suppress("mouse-focus", for: 0.15)
+        let result = workspaceManager.switchWorkspace(number, cursorScreen: screenUnderCursor())
+        if !result.alreadyVisible {
+            applyWorkspaceVisibility(result, windows: windows)
+            NotificationCenter.default.post(name: .hyprMacWorkspaceChanged, object: nil)
+        }
+        return workspaceManager.isWorkspaceVisible(number)
+    }
+
+    private func applyWorkspaceVisibility(_ result: WorkspaceManager.SwitchResult,
+                                          windows: [HyprWindow]) {
+        let windowsByID = Dictionary(windows.map { ($0.windowID, $0) },
+                                     uniquingKeysWith: { _, latest in latest })
+        for wid in result.toHide {
+            if let w = windowsByID[wid] ?? stateCache.cachedWindows[wid] {
+                if stateCache.floatingWindowIDs.contains(wid) { workspaceManager.saveFloatingFrame(w) }
+                workspaceManager.hideInCorner(w, on: result.screen)
+            }
+        }
+        for wid in result.toShow where stateCache.floatingWindowIDs.contains(wid) {
+            if let w = windowsByID[wid] ?? stateCache.cachedWindows[wid] {
+                workspaceManager.restoreFloatingFrame(w)
+            }
+        }
+    }
+
+    private func resolvedPreferredWindow(in visibleWindows: [HyprWindow],
+                                         resultIDs: Set<CGWindowID>,
+                                         preferredID: CGWindowID?,
+                                         fallback: HyprWindow?) -> HyprWindow? {
+        guard let preferredID, resultIDs.contains(preferredID) else { return nil }
+        return visibleWindows.first { $0.windowID == preferredID }
+            ?? (fallback?.windowID == preferredID ? fallback : nil)
+            ?? stateCache.cachedWindows[preferredID]
     }
 
     // MARK: - move focused window to workspace

--- a/HyprMac/Models/HyprWindow.swift
+++ b/HyprMac/Models/HyprWindow.swift
@@ -92,6 +92,13 @@ class HyprWindow: Equatable, Hashable {
         }
     }
 
+    /// A launch reservation has no AX window yet. Use the same conservative
+    /// bundle estimate as normal discovery, then validate the real window.
+    static func estimatedMinimumSize(for bundleIdentifier: String) -> CGSize {
+        heuristicMinimumSizes[bundleIdentifier]
+            ?? CGSize(width: TilingConfig.minSlotDimension, height: TilingConfig.minSlotDimension)
+    }
+
     private func axMinimumSize() -> CGSize? {
         for attribute in ["AXMinimumSize", "AXMinSize"] {
             var value: AnyObject?
@@ -254,7 +261,7 @@ class HyprWindow: Equatable, Hashable {
     /// the app and re-asserts focus 50 ms later — single-pass focus
     /// is unreliable when the app was not already active because the
     /// AX writes can race the activation.
-    func focus() {
+    func focus(reassertIf shouldReassert: @escaping () -> Bool = { true }) {
         let app = NSRunningApplication(processIdentifier: ownerPID)
         let alreadyActive = app?.isActive ?? false
         let wid = windowID
@@ -279,6 +286,10 @@ class HyprWindow: Equatable, Hashable {
             }
             let el = element
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                guard shouldReassert() else {
+                    hyprLog(.debug, .focus, "focus(\(wid)) re-assert cancelled by newer user intent")
+                    return
+                }
                 let r2 = AXUIElementPerformAction(el, kAXRaiseAction as CFString)
                 let m2 = AXUIElementSetAttributeValue(el, kAXMainAttribute as CFString, kCFBooleanTrue)
                 let f2 = AXUIElementSetAttributeValue(el, kAXFocusedAttribute as CFString, kCFBooleanTrue)

--- a/HyprMac/Settings/AppLauncherEditorSheet.swift
+++ b/HyprMac/Settings/AppLauncherEditorSheet.swift
@@ -19,7 +19,7 @@ struct AppLauncherEditorSheet: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: HyprSpacing.lg) {
-            Text("Add App Launcher")
+            Text("Open App with HyprMac")
                 .font(.hyprTitle)
 
             // app picker

--- a/HyprMac/Settings/KeybindDisplayHelpers.swift
+++ b/HyprMac/Settings/KeybindDisplayHelpers.swift
@@ -80,7 +80,7 @@ extension Keybind {
         case .toggleFloating:               return "Toggle Floating"
         case .toggleSplit:                  return "Toggle Split Direction"
         case .showKeybinds:                 return "Show Keybind Overlay"
-        case .launchApp(let b):             return "Launch \(appDisplayName(for: b))"
+        case .launchApp(let b):             return "Open \(appDisplayName(for: b)) with HyprMac"
         case .focusMenuBar:                 return "Focus Menu Bar"
         case .focusFloating:                return "Cycle Floating Windows"
         case .closeWindow:                  return "Close Window"

--- a/HyprMac/Settings/KeybindsSettingsView.swift
+++ b/HyprMac/Settings/KeybindsSettingsView.swift
@@ -39,6 +39,7 @@ struct KeybindsSettingsView: View {
         VStack(spacing: HyprSpacing.lg) {
             headerRow
             hyprHeroPanel
+            spotlightPanel
 
             ForEach(grouped, id: \.category) { group in
                 HyprPanel(group.category.rawValue) {
@@ -109,7 +110,7 @@ struct KeybindsSettingsView: View {
 
             Menu {
                 Button("Keybind…") { showingAddKeybind = true }
-                Button("App launcher…") { showingAddLauncher = true }
+                Button("Open app with HyprMac…") { showingAddLauncher = true }
             } label: {
                 HStack(spacing: 4) {
                     Image(systemName: "plus")
@@ -193,6 +194,52 @@ struct KeybindsSettingsView: View {
             RoundedRectangle(cornerRadius: HyprRadius.lg, style: .continuous)
                 .strokeBorder(Color.hyprCyan.opacity(0.22), lineWidth: 1)
         )
+    }
+
+    // MARK: Spotlight
+
+    private var spotlightPanel: some View {
+        HyprPanel("Spotlight") {
+            HStack(alignment: .top, spacing: HyprSpacing.md) {
+                Image(systemName: "sparkle.magnifyingglass")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(Color.hyprCyan)
+                    .frame(width: 26)
+
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Open App with HyprMac")
+                        .font(.hyprBody)
+                        .foregroundStyle(Color.hyprTextPrimary)
+
+                    if #available(macOS 26.0, *) {
+                        Text("Search for this action in Spotlight, choose an application, and run it. Spotlight learns from use and lets you assign its own Quick Key from the action menu.")
+                            .font(.hyprCaption)
+                            .foregroundStyle(Color.hyprTextSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        Text("Quick Keys are managed by macOS. Apple does not provide apps with a public API to assign or change them here.")
+                            .font(.hyprCaption)
+                            .foregroundStyle(Color.hyprTextTertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    } else {
+                        Text("Direct App Actions in Spotlight require macOS Tahoe 26 or later. The app hotkeys below use the same HyprMac activation path on this Mac.")
+                            .font(.hyprCaption)
+                            .foregroundStyle(Color.hyprTextSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                Spacer(minLength: HyprSpacing.sm)
+
+                Link(
+                    "Quick Key help",
+                    destination: URL(string: "https://support.apple.com/guide/mac-help/mchl4953dfeb/mac")!
+                )
+                .font(.hyprCaption)
+            }
+            .padding(.horizontal, HyprSpacing.md)
+            .padding(.vertical, HyprSpacing.md)
+        }
     }
 }
 

--- a/HyprMac/Tiling/LayoutEngine.swift
+++ b/HyprMac/Tiling/LayoutEngine.swift
@@ -4,12 +4,19 @@
 
 import Cocoa
 
+/// A temporary layout proposal; no placeholder window enters the BSP tree.
+struct LaunchLayoutPlan {
+    let siblingLayouts: [(HyprWindow, CGRect)]
+    let reservedFrame: CGRect
+}
+
 /// Geometric helpers for the tiling subsystem.
 ///
-/// Pure with respect to AX and animation. The only impure surface is
-/// `fittingLeaf` / `smartInsertFitting`, which need to look up
-/// min-sizes for windows already in the tree; callers pass that lookup
-/// in as a closure so this type does not depend on `MinSizeMemory`.
+/// Pure with respect to AX and animation. Callers supply minimum-size
+/// lookups so this type does not depend on `MinSizeMemory`. Smart insertion
+/// changes the tree; reservation planning temporarily normalizes its knobs
+/// and restores them before returning. Both run synchronously on the tree
+/// owner's queue, with no concurrent tree readers or mutations.
 struct LayoutEngine {
     let gapSize: CGFloat
     let outerPadding: CGFloat
@@ -97,6 +104,70 @@ struct LayoutEngine {
             }
         }
         return nil
+    }
+
+    /// Preview a cold-launch insertion before a real window exists. The
+    /// caller may move siblings, but must still validate the actual window's
+    /// minimum size and membership before revealing it. This conservative
+    /// midpoint proposal is not a promise of the final adaptive layout.
+    func planLaunchReservation(in tree: BSPTree,
+                               maxDepth: Int,
+                               rect: CGRect,
+                               incomingMinimumSize: CGSize,
+                               minimumSize: (HyprWindow?) -> CGSize) -> LaunchLayoutPlan? {
+        let slack = TilingConfig.rectComparisonSlackPx
+        func fits(_ size: CGSize, in frame: CGRect) -> Bool {
+            size.width.isFinite && size.height.isFinite
+                && size.width >= 0 && size.height >= 0
+                && frame.origin.x.isFinite && frame.origin.y.isFinite
+                && frame.width.isFinite && frame.height.isFinite
+                && frame.width > 0 && frame.height > 0
+                && size.width <= frame.width + slack
+                && size.height <= frame.height + slack
+        }
+
+        guard gapSize.isFinite, gapSize >= 0,
+              outerPadding.isFinite, outerPadding >= 0,
+              rect.width > 2 * outerPadding,
+              rect.height > 2 * outerPadding else { return nil }
+        let padded = rect.insetBy(dx: outerPadding, dy: outerPadding)
+        guard fits(incomingMinimumSize, in: padded) else { return nil }
+        if tree.root.isEmpty {
+            return LaunchLayoutPlan(siblingLayouts: [], reservedFrame: padded)
+        }
+
+        // Structural insertion clears user ratios, then starts its layout at
+        // default ratios. Reuse the tree's reversible knob snapshot without
+        // creating windows, making AX calls, or changing topology.
+        let saved = tree.snapshot()
+        defer { tree.restore(saved) }
+        tree.root.clearUserSetRatios()
+        tree.root.resetSplitRatios()
+        // insert() clears the selected leaf's override. Ignore stale leaf
+        // overrides during selection as well; internal overrides survive.
+        for leaf in tree.root.allLeavesRightToLeft() {
+            leaf.splitOverride = nil
+        }
+
+        let proposedMinimum: (HyprWindow?) -> CGSize = { window in
+            window == nil ? incomingMinimumSize : minimumSize(window)
+        }
+        guard let leaf = fittingLeaf(for: nil, in: tree, maxDepth: maxDepth,
+                                     rect: rect, minimumSize: proposedMinimum),
+              let tenant = leaf.window,
+              let leafRect = tree.rectForNode(leaf, in: rect, gap: gapSize, padding: outerPadding)
+        else { return nil }
+        let direction: SplitDirection = leafRect.width >= leafRect.height ? .horizontal : .vertical
+        let (tenantFrame, reservedFrame) = splitRects(leafRect, dir: direction)
+        guard fits(incomingMinimumSize, in: reservedFrame) else { return nil }
+
+        let siblings = tree.layout(in: rect, gap: gapSize, padding: outerPadding).map { window, frame in
+            (window, window === tenant ? tenantFrame : frame)
+        }
+        // pairFits permits unequal ratios; a reservation promises the exact
+        // midpoint rectangles, so validate every sibling after normalization.
+        guard siblings.allSatisfy({ fits(minimumSize($0.0), in: $0.1) }) else { return nil }
+        return LaunchLayoutPlan(siblingLayouts: siblings, reservedFrame: reservedFrame)
     }
 
     /// Smart-insert via `fittingLeaf`. Returns false if no leaf accepts the

--- a/HyprMac/Tiling/TilingEngine.swift
+++ b/HyprMac/Tiling/TilingEngine.swift
@@ -111,6 +111,21 @@ class TilingEngine {
         trees[TilingKey(workspace: workspace, screen: screen)]
     }
 
+    /// Predict one incoming tile without adding a fake window or changing
+    /// the live BSP tree. The caller writes only changed sibling frames and
+    /// later feeds the real window through ordinary discovery and tiling.
+    func planApplicationLaunch(onWorkspace workspace: Int, screen: NSScreen,
+                               estimatedMinimumSize: CGSize) -> LaunchLayoutPlan? {
+        let existing = trees[TilingKey(workspace: workspace, screen: screen)] ?? BSPTree()
+        return layoutEngine.planLaunchReservation(
+            in: existing,
+            maxDepth: maxDepth(for: screen),
+            rect: displayManager.cgRect(for: screen),
+            incomingMinimumSize: estimatedMinimumSize,
+            minimumSize: { [self] in minimumSize(for: $0) }
+        )
+    }
+
     /// Reconcile `trees` with the current monitor topology.
     ///
     /// When a screen is disconnected (e.g., laptop lid close, dock unplug), every

--- a/HyprMacTests/ApplicationActivationCoordinatorTests.swift
+++ b/HyprMacTests/ApplicationActivationCoordinatorTests.swift
@@ -1,0 +1,979 @@
+import Cocoa
+import XCTest
+@testable import HyprMac
+
+/// Deterministic virtual time for the activation workflow. Tests never wait on
+/// DispatchQueue and never touch a real application or Accessibility object.
+private final class ActivationTestScheduler {
+    private final class Task: ApplicationActivationScheduledTask {
+        let id: Int
+        let deadline: TimeInterval
+        let block: () -> Void
+        var isCancelled = false
+
+        init(id: Int, deadline: TimeInterval, block: @escaping () -> Void) {
+            self.id = id
+            self.deadline = deadline
+            self.block = block
+        }
+
+        func cancel() {
+            isCancelled = true
+        }
+    }
+
+    private var nextID = 0
+    private var tasks: [Task] = []
+    private(set) var now: TimeInterval = 0
+    private(set) var scheduledCount = 0
+
+    func schedule(after delay: TimeInterval,
+                  _ block: @escaping () -> Void) -> ApplicationActivationScheduledTask {
+        nextID += 1
+        scheduledCount += 1
+        let task = Task(id: nextID, deadline: now + max(0, delay), block: block)
+        tasks.append(task)
+        return task
+    }
+
+    func advance(by interval: TimeInterval) {
+        precondition(interval >= 0)
+        let destination = now + interval
+
+        while let task = nextRunnableTask(through: destination) {
+            tasks.removeAll { $0 === task }
+            now = task.deadline
+            if !task.isCancelled {
+                task.block()
+            }
+        }
+
+        now = destination
+        tasks.removeAll { $0.isCancelled }
+    }
+
+    private func nextRunnableTask(through deadline: TimeInterval) -> Task? {
+        tasks
+            .filter { !$0.isCancelled && $0.deadline <= deadline }
+            .min {
+                if $0.deadline != $1.deadline { return $0.deadline < $1.deadline }
+                return $0.id < $1.id
+            }
+    }
+}
+
+/// In-memory model of the small OS surface used by the coordinator.
+private final class ActivationTestSystem {
+    final class VisibilityProtection: ApplicationLaunchVisibilityProtecting {
+        private(set) var openedPIDs: [pid_t] = []
+        private(set) var finishCount = 0
+        private(set) var disarmCount = 0
+
+        func applicationOpened(pid: pid_t) { openedPIDs.append(pid) }
+        func finish() { finishCount += 1 }
+        func disarmAfterObservedReveal() { disarmCount += 1 }
+    }
+
+    struct OpenCall {
+        let url: URL
+        let hidden: Bool
+        let completion: (ApplicationOpenResult) -> Void
+    }
+
+    struct WindowCall: Equatable {
+        let pid: pid_t
+        let windowID: CGWindowID
+    }
+
+    struct WindowSetCall: Equatable {
+        let pid: pid_t
+        let windowIDs: Set<CGWindowID>
+        let selectedWindowID: CGWindowID
+    }
+
+    struct ReservationCall {
+        let bundleID: String
+        let requestID: UInt64
+        let completion: () -> Void
+    }
+
+    struct ReservationFinish: Equatable {
+        let requestID: UInt64
+        let result: ApplicationActivationResult
+    }
+
+    struct RouteCall: Equatable {
+        let pid: pid_t
+        let windowID: CGWindowID
+        let requestID: UInt64
+    }
+
+    let scheduler = ActivationTestScheduler()
+    private var installedApplications: [String: URL] = [:]
+    private(set) var processes: [String: ApplicationProcessSnapshot] = [:]
+    private(set) var inventories: [pid_t: ApplicationWindowInventory] = [:]
+
+    private(set) var applicationURLLookups: [String] = []
+    private(set) var processLookups: [String] = []
+    private(set) var openCalls: [OpenCall] = []
+    private(set) var unhideCalls: [pid_t] = []
+    private(set) var unminimizeCalls: [WindowCall] = []
+    private(set) var activateCalls: [pid_t] = []
+    private(set) var prepareCalls: [WindowSetCall] = []
+    private(set) var routeCalls: [RouteCall] = []
+    private(set) var discoveryDelays: [TimeInterval] = []
+    private(set) var events: [String] = []
+    private(set) var protections: [VisibilityProtection] = []
+    private(set) var protectionTimeouts: [TimeInterval] = []
+    private(set) var reservations: [ReservationCall] = []
+    private(set) var reservationFinishes: [ReservationFinish] = []
+
+    var prepareSucceeds = true
+    var routeSucceeds = true
+    var available = true
+    var lastFocusedWindowID: CGWindowID = 0
+    var automaticallyCompleteReservation = true
+
+    func install(_ bundleID: String) {
+        guard installedApplications[bundleID] == nil else { return }
+        installedApplications[bundleID] = URL(
+            fileURLWithPath: "/Applications/Test-\(installedApplications.count + 1).app"
+        )
+    }
+
+    func setProcess(_ bundleID: String,
+                    pid: pid_t,
+                    hidden: Bool,
+                    active: Bool = false) {
+        install(bundleID)
+        processes[bundleID] = ApplicationProcessSnapshot(
+            pid: pid,
+            isHidden: hidden,
+            isActive: active
+        )
+    }
+
+    func setInventory(_ inventory: ApplicationWindowInventory, for pid: pid_t) {
+        inventories[pid] = inventory
+    }
+
+    func completeOpen(at index: Int = 0,
+                      bundleID: String,
+                      pid: pid_t,
+                      hidden: Bool,
+                      active: Bool = false) {
+        setProcess(bundleID, pid: pid, hidden: hidden, active: active)
+        openCalls[index].completion(.opened(pid: pid))
+    }
+
+    func makeEnvironment() -> ApplicationActivationEnvironment {
+        ApplicationActivationEnvironment(
+            now: { [unowned self] in scheduler.now },
+            application: { [unowned self] bundleID, preferredPID in
+                processLookups.append(bundleID)
+                guard let process = processes[bundleID],
+                      preferredPID == nil || preferredPID == process.pid else { return nil }
+                return process
+            },
+            applicationURL: { [unowned self] bundleID in
+                applicationURLLookups.append(bundleID)
+                return installedApplications[bundleID]
+            },
+            inventory: { [unowned self] pid in
+                inventories[pid] ?? .unavailable
+            },
+            openApplication: { [unowned self] url, hidden, completion in
+                events.append(hidden ? "open-hidden" : "open-visible")
+                openCalls.append(OpenCall(url: url, hidden: hidden, completion: completion))
+            },
+            unhide: { [unowned self] pid in
+                events.append("unhide:\(pid)")
+                unhideCalls.append(pid)
+                return updateProcess(pid: pid, hidden: false)
+            },
+            unminimize: { [unowned self] pid, windowID in
+                events.append("unminimize:\(windowID)")
+                unminimizeCalls.append(WindowCall(pid: pid, windowID: windowID))
+                return updateWindow(pid: pid, windowID: windowID, minimized: false)
+            },
+            activate: { [unowned self] pid in
+                events.append("activate:\(pid)")
+                activateCalls.append(pid)
+                return updateProcess(pid: pid, active: true)
+            },
+            protectHiddenLaunch: { [unowned self] _, timeout in
+                let protection = VisibilityProtection()
+                protections.append(protection)
+                protectionTimeouts.append(timeout)
+                return protection
+            },
+            schedule: { [unowned self] delay, block in
+                scheduler.schedule(after: delay, block)
+            }
+        )
+    }
+
+    func wire(_ coordinator: ApplicationActivationCoordinator) {
+        coordinator.prepareWindowsForReveal = { [unowned self] pid, windowIDs, selectedWindowID in
+            events.append("prepare")
+            prepareCalls.append(WindowSetCall(pid: pid, windowIDs: windowIDs, selectedWindowID: selectedWindowID))
+            return prepareSucceeds
+        }
+        coordinator.reserveSpaceBeforeLaunch = { [unowned self] bundleID, requestID, completion in
+            events.append("reserve")
+            reservations.append(ReservationCall(bundleID: bundleID, requestID: requestID, completion: completion))
+            if automaticallyCompleteReservation { completeReservation() }
+        }
+        coordinator.finishLaunchReservation = { [unowned self] requestID, result in
+            reservationFinishes.append(ReservationFinish(requestID: requestID, result: result))
+        }
+        coordinator.routeWindow = { [unowned self] pid, windowID, requestID in
+            events.append("route:\(windowID)")
+            routeCalls.append(RouteCall(pid: pid, windowID: windowID, requestID: requestID))
+            return routeSucceeds
+        }
+        coordinator.requestDiscovery = { [unowned self] delay in
+            discoveryDelays.append(delay)
+        }
+        coordinator.lastFocusedWindowID = { [unowned self] in lastFocusedWindowID }
+        coordinator.isAvailable = { [unowned self] in available }
+    }
+
+    func completeReservation(at index: Int = 0) {
+        events.append("reservation-complete")
+        reservations[index].completion()
+    }
+
+    @discardableResult
+    private func updateProcess(pid: pid_t,
+                               hidden: Bool? = nil,
+                               active: Bool? = nil) -> Bool {
+        guard let entry = processes.first(where: { $0.value.pid == pid }) else { return false }
+        processes[entry.key] = ApplicationProcessSnapshot(
+            pid: pid,
+            isHidden: hidden ?? entry.value.isHidden,
+            isActive: active ?? entry.value.isActive
+        )
+        return true
+    }
+
+    @discardableResult
+    private func updateWindow(pid: pid_t,
+                              windowID: CGWindowID,
+                              minimized: Bool) -> Bool {
+        guard case .available(let windows, let hasUnaddressableWindows) = inventories[pid],
+              windows.contains(where: { $0.windowID == windowID }) else { return false }
+        inventories[pid] = .available(
+            windows: windows.map { window in
+                guard window.windowID == windowID else { return window }
+                return ApplicationWindowCandidate(
+                    windowID: window.windowID,
+                    isMinimized: minimized,
+                    isMain: window.isMain,
+                    isFocused: window.isFocused
+                )
+            },
+            hasUnaddressableWindows: hasUnaddressableWindows
+        )
+        return true
+    }
+}
+
+final class ApplicationActivationCoordinatorTests: XCTestCase {
+    private let appA = "com.example.alpha"
+    private let appB = "com.example.beta"
+
+    private func makeCoordinator(
+        system: ActivationTestSystem,
+        hardTimeout: TimeInterval = 1.0,
+        quietPeriod: TimeInterval = 0.1,
+        noWindowGrace: TimeInterval = 0.2
+    ) -> ApplicationActivationCoordinator {
+        let coordinator = ApplicationActivationCoordinator(
+            environment: system.makeEnvironment(),
+            hardTimeout: hardTimeout,
+            windowQuietPeriod: quietPeriod,
+            windowBurstCap: 0.4,
+            noWindowGrace: noWindowGrace
+        )
+        system.wire(coordinator)
+        return coordinator
+    }
+
+    private func window(_ id: CGWindowID,
+                        minimized: Bool = false,
+                        main: Bool = false,
+                        focused: Bool = false) -> ApplicationWindowCandidate {
+        ApplicationWindowCandidate(
+            windowID: id,
+            isMinimized: minimized,
+            isMain: main,
+            isFocused: focused
+        )
+    }
+
+    func testUnknownApplicationReturnsUnavailableWithoutSideEffects() {
+        let system = ActivationTestSystem()
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .hotkey) { results.append($0) }
+
+        XCTAssertEqual(results, [.unavailable])
+        XCTAssertEqual(system.applicationURLLookups, [appA])
+        XCTAssertTrue(system.processLookups.isEmpty)
+        XCTAssertTrue(system.openCalls.isEmpty)
+        XCTAssertTrue(system.unhideCalls.isEmpty)
+        XCTAssertTrue(system.unminimizeCalls.isEmpty)
+        XCTAssertTrue(system.activateCalls.isEmpty)
+        XCTAssertTrue(system.prepareCalls.isEmpty)
+        XCTAssertTrue(system.routeCalls.isEmpty)
+        XCTAssertEqual(system.scheduler.scheduledCount, 0)
+    }
+
+    func testConfirmedEmptyRunningApplicationReopensExactlyOnce() {
+        let system = ActivationTestSystem()
+        system.setProcess(appA, pid: 101, hidden: false)
+        system.setInventory(.available(windows: [], hasUnaddressableWindows: false), for: 101)
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .hotkey) { results.append($0) }
+        XCTAssertEqual(system.openCalls.count, 1)
+        XCTAssertFalse(system.openCalls[0].hidden)
+
+        system.openCalls[0].completion(.opened(pid: 101))
+        coordinator.noteAXEvent(pid: 101)
+        coordinator.noteDiscoveryCompleted()
+        system.scheduler.advance(by: 0.25)
+
+        XCTAssertEqual(system.openCalls.count, 1, "empty-window probes must not reopen repeatedly")
+        XCTAssertEqual(system.activateCalls, [101])
+        XCTAssertEqual(results, [.openedWithoutWindow])
+    }
+
+    func testUnavailableAXNeverReopensAndFailsOpenSafely() {
+        let system = ActivationTestSystem()
+        system.setProcess(appA, pid: 102, hidden: true)
+        system.setInventory(.unavailable, for: 102)
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { results.append($0) }
+        system.scheduler.advance(by: 0)
+
+        XCTAssertTrue(system.openCalls.isEmpty, "unreadable AX state is not proof of an empty app")
+        XCTAssertEqual(system.unhideCalls, [102])
+        XCTAssertEqual(system.activateCalls, [102])
+        XCTAssertEqual(results, [.openedWithoutWindow])
+    }
+
+    func testOnlySelectedMinimizedWindowIsRestored() {
+        let system = ActivationTestSystem()
+        system.setProcess(appA, pid: 103, hidden: false)
+        system.lastFocusedWindowID = 20
+        system.setInventory(
+            .available(
+                windows: [
+                    window(10, minimized: true, main: true, focused: true),
+                    window(20, minimized: true),
+                    window(30, minimized: true)
+                ],
+                hasUnaddressableWindows: false
+            ),
+            for: 103
+        )
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .hotkey) { results.append($0) }
+
+        XCTAssertEqual(system.prepareCalls, [
+            ActivationTestSystem.WindowSetCall(pid: 103, windowIDs: [20], selectedWindowID: 20)
+        ])
+        XCTAssertEqual(system.unminimizeCalls, [
+            ActivationTestSystem.WindowCall(pid: 103, windowID: 20)
+        ])
+
+        system.scheduler.advance(by: 0.05)
+        XCTAssertEqual(system.routeCalls.map(\.windowID), [20])
+        XCTAssertEqual(results, [.activated(windowID: 20)])
+    }
+
+    func testSelectionOrderIsLastFocusedThenFocusedThenMainThenWindowID() {
+        func selected(from windows: [ApplicationWindowCandidate],
+                      lastFocused: CGWindowID = 0) -> CGWindowID? {
+            let system = ActivationTestSystem()
+            system.setProcess(appA, pid: 104, hidden: false)
+            system.setInventory(
+                .available(windows: windows, hasUnaddressableWindows: false),
+                for: 104
+            )
+            system.lastFocusedWindowID = lastFocused
+            let coordinator = makeCoordinator(system: system)
+            _ = coordinator.activate(bundleID: appA, source: .hotkey) { _ in }
+            return system.routeCalls.first?.windowID
+        }
+
+        XCTAssertEqual(
+            selected(
+                from: [
+                    window(10, focused: true),
+                    window(20, main: true),
+                    window(30),
+                    window(40)
+                ],
+                lastFocused: 40
+            ),
+            40
+        )
+        XCTAssertEqual(selected(from: [window(20, main: true), window(10, focused: true)]), 10)
+        XCTAssertEqual(selected(from: [window(20, main: true), window(10)]), 20)
+        XCTAssertEqual(selected(from: [window(20), window(10)]), 10)
+    }
+
+    func testColdHiddenLaunchPreparesAllWindowsBeforeRevealAndRoute() {
+        let system = ActivationTestSystem()
+        system.install(appA)
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { results.append($0) }
+        system.scheduler.advance(by: 0)
+        XCTAssertEqual(system.openCalls.count, 1)
+        XCTAssertTrue(system.openCalls[0].hidden)
+
+        system.setInventory(
+            .available(
+                windows: [window(201), window(202, main: true), window(203, minimized: true)],
+                hasUnaddressableWindows: false
+            ),
+            for: 105
+        )
+        system.completeOpen(bundleID: appA, pid: 105, hidden: true)
+        system.scheduler.advance(by: 0)
+
+        system.scheduler.advance(by: 0.099)
+        XCTAssertTrue(system.prepareCalls.isEmpty)
+        XCTAssertTrue(system.unhideCalls.isEmpty)
+
+        system.scheduler.advance(by: 0.002)
+        XCTAssertEqual(system.prepareCalls, [
+            ActivationTestSystem.WindowSetCall(pid: 105, windowIDs: [201, 202], selectedWindowID: 202)
+        ])
+        XCTAssertEqual(system.unhideCalls, [105])
+        XCTAssertTrue(system.unminimizeCalls.isEmpty, "unselected minimized windows must stay minimized")
+        XCTAssertTrue(system.routeCalls.isEmpty)
+
+        system.scheduler.advance(by: 0.05)
+        XCTAssertEqual(system.routeCalls.map(\.windowID), [202])
+        XCTAssertEqual(results, [.activated(windowID: 202)])
+
+        let prepareIndex = system.events.firstIndex(of: "prepare")
+        let unhideIndex = system.events.firstIndex(of: "unhide:105")
+        let routeIndex = system.events.firstIndex(of: "route:202")
+        guard let prepareIndex, let unhideIndex, let routeIndex else {
+            return XCTFail("expected prepare, unhide, and route events")
+        }
+        XCTAssertLessThan(prepareIndex, unhideIndex)
+        XCTAssertLessThan(unhideIndex, routeIndex)
+    }
+
+    func testTimeoutFailsOpenByUnhidingAndActivating() {
+        let system = ActivationTestSystem()
+        system.install(appA)
+        let coordinator = makeCoordinator(system: system, hardTimeout: 0.5)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { results.append($0) }
+        system.scheduler.advance(by: 0)
+        system.setInventory(.unavailable, for: 106)
+        system.completeOpen(bundleID: appA, pid: 106, hidden: true)
+        system.scheduler.advance(by: 0)
+        system.scheduler.advance(by: 0.51)
+
+        XCTAssertEqual(system.unhideCalls, [106])
+        XCTAssertEqual(system.activateCalls, [106])
+        XCTAssertEqual(results, [.timedOut])
+        XCTAssertTrue(system.prepareCalls.isEmpty)
+        XCTAssertTrue(system.routeCalls.isEmpty)
+    }
+
+    func testSameBundleRequestsCoalesceOntoOneLaunch() {
+        let system = ActivationTestSystem()
+        system.install(appA)
+        let coordinator = makeCoordinator(system: system)
+        var firstResults: [ApplicationActivationResult] = []
+        var secondResults: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .hotkey) { firstResults.append($0) }
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { secondResults.append($0) }
+        system.scheduler.advance(by: 0)
+        XCTAssertEqual(system.openCalls.count, 1)
+
+        system.setInventory(
+            .available(windows: [window(301)], hasUnaddressableWindows: false),
+            for: 107
+        )
+        system.completeOpen(bundleID: appA, pid: 107, hidden: true)
+        system.scheduler.advance(by: 0)
+        system.scheduler.advance(by: 0.11)
+        system.scheduler.advance(by: 0.05)
+
+        XCTAssertEqual(system.openCalls.count, 1)
+        XCTAssertEqual(firstResults, [.activated(windowID: 301)])
+        XCTAssertEqual(secondResults, [.activated(windowID: 301)])
+    }
+
+    func testDifferentBundleCancelsOldRequestAndStaleOpenCannotStealFocus() {
+        let system = ActivationTestSystem()
+        system.install(appA)
+        system.setProcess(appB, pid: 109, hidden: false)
+        system.setInventory(
+            .available(windows: [window(401)], hasUnaddressableWindows: false),
+            for: 109
+        )
+        let coordinator = makeCoordinator(system: system)
+        var firstResults: [ApplicationActivationResult] = []
+        var secondResults: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { firstResults.append($0) }
+        system.scheduler.advance(by: 0)
+        _ = coordinator.activate(bundleID: appB, source: .hotkey) { secondResults.append($0) }
+        system.scheduler.advance(by: 0)
+
+        XCTAssertEqual(firstResults, [.cancelled])
+        XCTAssertEqual(secondResults, [.activated(windowID: 401)])
+
+        // Launch Services may finish A after its request was superseded. It
+        // must be made visible for safety, but never activated or routed.
+        system.setInventory(.unavailable, for: 108)
+        system.completeOpen(at: 0, bundleID: appA, pid: 108, hidden: true)
+        system.scheduler.advance(by: 1.1)
+
+        XCTAssertEqual(system.unhideCalls, [108])
+        XCTAssertFalse(system.activateCalls.contains(108))
+        XCTAssertEqual(system.routeCalls.map(\.pid), [109])
+        XCTAssertEqual(firstResults, [.cancelled])
+        XCTAssertEqual(secondResults, [.activated(windowID: 401)])
+    }
+
+    func testForeignActivationImmediatelyCancelsRequest() {
+        let system = ActivationTestSystem()
+        system.install(appA)
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { results.append($0) }
+        let claim = coordinator.noteApplicationActivated(bundleID: appB, pid: 202)
+        system.scheduler.advance(by: 0)
+
+        XCTAssertEqual(claim, .cancelledForUserOverride)
+        XCTAssertEqual(results, [.cancelled])
+    }
+
+    func testMatchingActivationIsClaimedAndRequestContinues() {
+        let system = ActivationTestSystem()
+        system.install(appA)
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { results.append($0) }
+        system.scheduler.advance(by: 0)
+        system.setProcess(appA, pid: 110, hidden: false, active: true)
+        system.setInventory(
+            .available(windows: [window(501, focused: true)], hasUnaddressableWindows: false),
+            for: 110
+        )
+
+        let claim = coordinator.noteApplicationActivated(bundleID: appA, pid: 110)
+        system.scheduler.advance(by: 0)
+
+        XCTAssertEqual(claim, .claimed)
+        XCTAssertEqual(results, [.activated(windowID: 501)])
+        XCTAssertEqual(system.routeCalls.map(\.windowID), [501])
+    }
+
+    func testFilteredWindowsAreNotTreatedAsConfirmedEmpty() {
+        let system = ActivationTestSystem()
+        system.setProcess(appA, pid: 111, hidden: false)
+        system.setInventory(
+            .available(windows: [], hasUnaddressableWindows: true),
+            for: 111
+        )
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .hotkey) { results.append($0) }
+        system.scheduler.advance(by: 0)
+
+        XCTAssertTrue(system.openCalls.isEmpty)
+        XCTAssertEqual(system.activateCalls, [111])
+        XCTAssertEqual(results, [.openedWithoutWindow])
+    }
+
+    func testSelectedWindowDoesNotChangeWhileRestoring() {
+        let system = ActivationTestSystem()
+        system.setProcess(appA, pid: 112, hidden: true)
+        system.lastFocusedWindowID = 601
+        system.setInventory(
+            .available(windows: [window(601), window(602, focused: true)],
+                       hasUnaddressableWindows: false),
+            for: 112
+        )
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .hotkey) { results.append($0) }
+        system.lastFocusedWindowID = 602
+        system.scheduler.advance(by: 0.05)
+
+        XCTAssertEqual(system.routeCalls.map(\.windowID), [601])
+        XCTAssertEqual(results, [.activated(windowID: 601)])
+    }
+
+    func testCancellingKnownColdLaunchUnhidesWithoutActivating() {
+        let system = ActivationTestSystem()
+        system.install(appA)
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        let handle = coordinator.activate(bundleID: appA, source: .spotlight) {
+            results.append($0)
+        }
+        system.scheduler.advance(by: 0)
+        system.setInventory(.unavailable, for: 113)
+        system.completeOpen(bundleID: appA, pid: 113, hidden: true)
+        system.scheduler.advance(by: 0)
+
+        handle.cancel()
+        system.scheduler.advance(by: 0)
+
+        XCTAssertEqual(results, [.cancelled])
+        XCTAssertEqual(system.unhideCalls, [113])
+        XCTAssertTrue(system.activateCalls.isEmpty)
+    }
+
+    func testColdLaunchWaitsForReservationAndUsesRemainingDeadline() {
+        let system = ActivationTestSystem()
+        system.install(appA)
+        system.automaticallyCompleteReservation = false
+        let coordinator = makeCoordinator(system: system)
+
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { _ in }
+        system.scheduler.advance(by: 0.3)
+        XCTAssertEqual(system.events, ["reserve"])
+        XCTAssertTrue(system.openCalls.isEmpty)
+
+        system.completeReservation()
+        XCTAssertTrue(system.openCalls.isEmpty, "opening must yield to already queued user input")
+        system.scheduler.advance(by: 0)
+
+        XCTAssertEqual(system.events, ["reserve", "reservation-complete", "open-hidden"])
+        XCTAssertEqual(system.openCalls.count, 1)
+        XCTAssertEqual(system.protectionTimeouts.first ?? -1, 0.7, accuracy: 0.000_001)
+    }
+
+    func testCancellationDuringReservationPreventsLaunch() {
+        let system = ActivationTestSystem()
+        system.install(appA)
+        system.automaticallyCompleteReservation = false
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        let handle = coordinator.activate(bundleID: appA, source: .hotkey) { results.append($0) }
+        handle.cancel()
+        system.scheduler.advance(by: 0)
+        system.completeReservation()
+        system.scheduler.advance(by: 1.1)
+
+        XCTAssertTrue(system.openCalls.isEmpty)
+        XCTAssertTrue(system.protections.isEmpty)
+        XCTAssertEqual(results, [.cancelled])
+        XCTAssertEqual(system.reservationFinishes.map(\.result), [.cancelled])
+    }
+
+    func testAppStartedExternallyDuringReservationUsesExistingWindowPath() {
+        let system = ActivationTestSystem()
+        system.install(appA)
+        system.automaticallyCompleteReservation = false
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { results.append($0) }
+        system.setProcess(appA, pid: 114, hidden: false)
+        system.setInventory(
+            .available(windows: [window(701)], hasUnaddressableWindows: false),
+            for: 114
+        )
+        system.completeReservation()
+        system.scheduler.advance(by: 0)
+
+        XCTAssertTrue(system.openCalls.isEmpty, "never hide an app that started during preflow")
+        XCTAssertTrue(system.protections.isEmpty)
+        XCTAssertEqual(system.routeCalls.map(\.windowID), [701])
+        XCTAssertEqual(results, [.activated(windowID: 701)])
+    }
+
+    func testModalAlongsideStandardWindowUsesAppOwnedFocus() {
+        let system = ActivationTestSystem()
+        system.setProcess(appA, pid: 115, hidden: true)
+        system.setInventory(
+            .available(windows: [window(801)], hasUnaddressableWindows: true),
+            for: 115
+        )
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { results.append($0) }
+        system.scheduler.advance(by: 0)
+
+        XCTAssertTrue(system.openCalls.isEmpty)
+        XCTAssertTrue(system.prepareCalls.isEmpty)
+        XCTAssertTrue(system.routeCalls.isEmpty, "do not raise a document above the app's dialog")
+        XCTAssertEqual(system.unhideCalls, [115])
+        XCTAssertEqual(system.activateCalls, [115])
+        XCTAssertEqual(results, [.openedWithoutWindow])
+    }
+
+    func testDelayedTriggerInputIsIgnoredButNewInputCancelsRequest() {
+        let system = ActivationTestSystem()
+        system.install(appA)
+        system.automaticallyCompleteReservation = false
+        system.scheduler.advance(by: 10)
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { results.append($0) }
+        coordinator.cancelForUserOverride(eventTimestamp: 9.9)
+        system.scheduler.advance(by: 0)
+        XCTAssertTrue(results.isEmpty)
+        XCTAssertTrue(system.reservationFinishes.isEmpty)
+
+        coordinator.cancelForUserOverride(eventTimestamp: 10.1)
+        system.scheduler.advance(by: 0)
+        XCTAssertEqual(results, [.cancelled])
+    }
+
+    func testDelayedTriggerInputPreservesFocusTailButNewInputInvalidatesIt() {
+        let system = ActivationTestSystem()
+        system.setProcess(appA, pid: 116, hidden: false)
+        system.setInventory(
+            .available(windows: [window(901)], hasUnaddressableWindows: false),
+            for: 116
+        )
+        system.scheduler.advance(by: 10)
+        let coordinator = makeCoordinator(system: system)
+
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { _ in }
+        system.scheduler.advance(by: 0)
+        guard let requestID = system.routeCalls.first?.requestID else {
+            return XCTFail("expected an exact-window route")
+        }
+
+        coordinator.cancelForUserOverride(eventTimestamp: 9.9)
+        XCTAssertTrue(coordinator.allowsFocusReassertion(for: requestID))
+        coordinator.cancelForUserOverride(eventTimestamp: 10.1)
+        XCTAssertFalse(coordinator.allowsFocusReassertion(for: requestID))
+    }
+
+    func testLateOpenCallbackRespectsManualHideAfterObservedReveal() {
+        let system = ActivationTestSystem()
+        system.install(appA)
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { results.append($0) }
+        system.scheduler.advance(by: 0)
+        system.setProcess(appA, pid: 117, hidden: true)
+        system.setInventory(
+            .available(windows: [window(902)], hasUnaddressableWindows: false),
+            for: 117
+        )
+        coordinator.noteApplicationLaunched(bundleID: appA, pid: 117)
+        system.scheduler.advance(by: 0.16)
+        XCTAssertEqual(results, [.activated(windowID: 902)])
+        XCTAssertEqual(system.unhideCalls, [117])
+        XCTAssertEqual(system.protections.first?.disarmCount, 1)
+
+        system.completeOpen(bundleID: appA, pid: 117, hidden: true)
+        system.scheduler.advance(by: 0)
+        XCTAssertEqual(system.unhideCalls, [117], "a late callback must not undo a later Cmd-H")
+    }
+
+    func testUnknownSecondApplicationCancelsPendingRequestWithoutStealingFocus() {
+        let system = ActivationTestSystem()
+        system.install(appA)
+        let coordinator = makeCoordinator(system: system)
+        var firstResults: [ApplicationActivationResult] = []
+        var secondResults: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { firstResults.append($0) }
+        system.scheduler.advance(by: 0)
+        _ = coordinator.activate(bundleID: appB, source: .hotkey) { secondResults.append($0) }
+        XCTAssertEqual(secondResults, [.unavailable])
+        system.scheduler.advance(by: 0)
+        XCTAssertEqual(firstResults, [.cancelled])
+
+        system.completeOpen(bundleID: appA, pid: 118, hidden: true)
+        system.scheduler.advance(by: 1.1)
+        XCTAssertEqual(system.unhideCalls, [118])
+        XCTAssertTrue(system.activateCalls.isEmpty)
+        XCTAssertTrue(system.routeCalls.isEmpty)
+        XCTAssertEqual(firstResults, [.cancelled])
+    }
+
+    func testTimeoutDuringReservationNeverStartsApplication() {
+        let system = ActivationTestSystem()
+        system.install(appA)
+        system.automaticallyCompleteReservation = false
+        let coordinator = makeCoordinator(system: system, hardTimeout: 0.5)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { results.append($0) }
+        system.scheduler.advance(by: 0.51)
+        system.completeReservation()
+        system.scheduler.advance(by: 0)
+
+        XCTAssertEqual(results, [.timedOut])
+        XCTAssertEqual(system.reservationFinishes.map(\.result), [.timedOut])
+        XCTAssertTrue(system.openCalls.isEmpty)
+        XCTAssertTrue(system.protections.isEmpty)
+        XCTAssertTrue(system.activateCalls.isEmpty)
+    }
+
+    func testSameBundleLaunchNotificationCannotReplaceEstablishedPID() {
+        let system = ActivationTestSystem()
+        system.setProcess(appA, pid: 119, hidden: false)
+        system.setInventory(
+            .available(windows: [window(903)], hasUnaddressableWindows: false),
+            for: 119
+        )
+        system.routeSucceeds = false
+        let coordinator = makeCoordinator(system: system)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .hotkey) { results.append($0) }
+        coordinator.noteApplicationLaunched(bundleID: appA, pid: 120)
+        coordinator.noteAXEvent(pid: 120)
+        system.routeSucceeds = true
+        coordinator.noteDiscoveryCompleted()
+        system.scheduler.advance(by: 0.05)
+
+        XCTAssertEqual(system.routeCalls.map(\.pid), [119, 119])
+        XCTAssertEqual(results, [.activated(windowID: 903)])
+    }
+
+    func testCompletionCanStartAnotherActivationWithoutLosingIt() {
+        let system = ActivationTestSystem()
+        system.setProcess(appA, pid: 121, hidden: false)
+        system.setProcess(appB, pid: 122, hidden: false)
+        system.setInventory(.available(windows: [window(904)], hasUnaddressableWindows: false), for: 121)
+        system.setInventory(.available(windows: [window(905)], hasUnaddressableWindows: false), for: 122)
+        let coordinator = makeCoordinator(system: system)
+        var firstResults: [ApplicationActivationResult] = []
+        var secondResults: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .hotkey) { result in
+            firstResults.append(result)
+            _ = coordinator.activate(bundleID: self.appB, source: .spotlight) { secondResults.append($0) }
+        }
+        system.scheduler.advance(by: 0)
+
+        XCTAssertEqual(firstResults, [.activated(windowID: 904)])
+        XCTAssertEqual(secondResults, [.activated(windowID: 905)])
+        XCTAssertEqual(system.routeCalls.map(\.pid), [121, 122])
+    }
+
+    func testFailedRouteAndDiscoveryStormRemainBounded() {
+        let system = ActivationTestSystem()
+        system.setProcess(appA, pid: 123, hidden: false)
+        system.setInventory(.available(windows: [window(906)], hasUnaddressableWindows: false), for: 123)
+        system.routeSucceeds = false
+        let coordinator = makeCoordinator(system: system, hardTimeout: 0.5)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .hotkey) { results.append($0) }
+        for _ in 0..<100 {
+            coordinator.noteDiscoveryCompleted()
+            system.scheduler.advance(by: 0)
+        }
+        XCTAssertEqual(system.routeCalls.count, 1, "discovery must not start a zero-delay route loop")
+        system.scheduler.advance(by: 0.51)
+
+        XCTAssertTrue(system.routeCalls.count <= 8, "route retries must remain time-gated")
+        XCTAssertTrue(system.discoveryDelays.count <= 6, "failed routes must coalesce discovery")
+        XCTAssertEqual(results, [.timedOut])
+    }
+
+    func testNoWindowGraceStartsAtLateProcessAppearance() {
+        let system = ActivationTestSystem()
+        system.install(appA)
+        let coordinator = makeCoordinator(system: system, hardTimeout: 2)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .spotlight) { results.append($0) }
+        system.scheduler.advance(by: 0.7)
+        system.setInventory(.available(windows: [], hasUnaddressableWindows: false), for: 124)
+        system.completeOpen(bundleID: appA, pid: 124, hidden: true)
+        system.scheduler.advance(by: 0.19)
+        XCTAssertTrue(results.isEmpty, "a slow process still gets its own window-creation grace")
+        XCTAssertTrue(system.unhideCalls.isEmpty)
+
+        system.scheduler.advance(by: 0.06)
+        XCTAssertEqual(results, [.openedWithoutWindow])
+        XCTAssertEqual(system.unhideCalls, [124])
+    }
+
+    func testNoWindowGraceStartsAtLateReopen() {
+        let system = ActivationTestSystem()
+        system.setProcess(appA, pid: 125, hidden: false)
+        system.setInventory(.available(windows: [window(907)], hasUnaddressableWindows: false), for: 125)
+        system.routeSucceeds = false
+        let coordinator = makeCoordinator(system: system, hardTimeout: 2)
+        var results: [ApplicationActivationResult] = []
+
+        _ = coordinator.activate(bundleID: appA, source: .hotkey) { results.append($0) }
+        system.scheduler.advance(by: 0.5)
+        system.setInventory(.available(windows: [], hasUnaddressableWindows: false), for: 125)
+        coordinator.noteAXEvent(pid: 125)
+        system.scheduler.advance(by: 0.031)
+        XCTAssertEqual(system.openCalls.count, 1)
+        system.openCalls[0].completion(.opened(pid: 125))
+        system.scheduler.advance(by: 0.19)
+        XCTAssertTrue(results.isEmpty, "reopen grace must not use the old trigger timestamp")
+
+        system.scheduler.advance(by: 0.06)
+        XCTAssertEqual(results, [.openedWithoutWindow])
+        XCTAssertEqual(system.openCalls.count, 1)
+    }
+
+    func testDeinitializationReleasesSubscriberCaptureWhileTimersRemainPending() {
+        let system = ActivationTestSystem()
+        system.setProcess(appA, pid: 126, hidden: false)
+        system.setInventory(.available(windows: [window(908)], hasUnaddressableWindows: false), for: 126)
+        system.routeSucceeds = false
+        var coordinator: ApplicationActivationCoordinator? = makeCoordinator(system: system)
+        weak var observedCoordinator: ApplicationActivationCoordinator?
+        observedCoordinator = coordinator
+        weak var capturedObject: NSObject?
+
+        do {
+            let object = NSObject()
+            capturedObject = object
+            _ = coordinator?.activate(bundleID: appA, source: .hotkey) { [object] _ in
+                withExtendedLifetime(object) {}
+            }
+        }
+        XCTAssertFalse(capturedObject == nil, "the in-flight subscriber should retain its capture")
+        XCTAssertTrue(system.openCalls.isEmpty)
+
+        coordinator = nil
+
+        XCTAssertTrue(observedCoordinator == nil)
+        XCTAssertTrue(capturedObject == nil, "pending timers must not keep the request/subscriber alive")
+        system.scheduler.advance(by: 1.1)
+        XCTAssertEqual(system.routeCalls.count, 1)
+        XCTAssertTrue(system.activateCalls.isEmpty)
+    }
+}

--- a/HyprMacTests/ApplicationLaunchVisibilityGuardTests.swift
+++ b/HyprMacTests/ApplicationLaunchVisibilityGuardTests.swift
@@ -1,0 +1,217 @@
+import Cocoa
+import XCTest
+@testable import HyprMac
+
+final class ApplicationLaunchVisibilityGuardTests: XCTestCase {
+    private final class Process: ApplicationLaunchVisibilityProcess {
+        let bundleIdentifier: String? = "test.application"
+        var isTerminated = false
+        var isHidden = true
+        var unhideRequests = 0
+        var onUnhide: (() -> Void)?
+        var acceptsUnhide = true
+
+        func unhide() -> Bool {
+            unhideRequests += 1
+            onUnhide?()
+            return acceptsUnhide
+        }
+
+        func isSameProcess(as other: ApplicationLaunchVisibilityProcess) -> Bool { self === other }
+    }
+
+    private final class Fixture {
+        let queue = DispatchQueue(label: "test.launch-visibility")
+        // Tests mutate/read these only before guard creation or on queue.
+        var applications: [Process]
+        var byPID: [pid_t: Process] = [:]
+
+        init(initial: [Process] = []) { applications = initial }
+
+        func makeGuard(timeout: TimeInterval = 60, attempts: Int = 3) -> ApplicationLaunchVisibilityGuard {
+            ApplicationLaunchVisibilityGuard(
+                bundleID: "test.application", timeout: timeout,
+                environment: .init(
+                    runningApplications: { [weak self] _ in self?.applications ?? [] },
+                    applicationForPID: { [weak self] in self?.byPID[$0] }
+                ),
+                queue: queue, maximumAttempts: attempts, retryInterval: 0.005
+            )
+        }
+
+        func add(_ process: Process, pid: pid_t = 1) {
+            queue.sync {
+                applications.append(process)
+                byPID[pid] = process
+            }
+        }
+
+        func drain() { queue.sync {} }
+
+        func allowRetries() {
+            let done = DispatchSemaphore(value: 0)
+            queue.asyncAfter(deadline: .now() + 0.08) { done.signal() }
+            XCTAssertEqual(done.wait(timeout: .now() + 1), .success)
+        }
+    }
+
+    func testDeadlineFindsNewProcessWithoutMainQueueCompletion() {
+        let fixture = Fixture()
+        let guardObject = fixture.makeGuard(timeout: 0.02)
+        defer { guardObject.disarmAfterObservedReveal(); fixture.drain() }
+        let process = Process()
+        let requested = DispatchSemaphore(value: 0)
+        process.onUnhide = { requested.signal() }
+        fixture.add(process)
+        // The test deliberately blocks main: rescue must not need its timer,
+        // run loop, NSWorkspace completion, or any live app/AX operation.
+        XCTAssertEqual(requested.wait(timeout: .now() + 1), .success)
+        XCTAssertGreaterThan(fixture.queue.sync { process.unhideRequests }, 0)
+    }
+
+    func testObservedRevealDisarmsFinishAndLateCompletion() {
+        let fixture = Fixture()
+        let guardObject = fixture.makeGuard()
+        let process = Process()
+        fixture.add(process)
+        guardObject.disarmAfterObservedReveal()
+        // A later manual hide belongs to the user, not this launch request.
+        fixture.queue.sync { process.isHidden = true }
+        guardObject.finish()
+        guardObject.applicationOpened(pid: 1)
+        fixture.drain()
+        XCTAssertEqual(fixture.queue.sync { process.unhideRequests }, 0)
+    }
+
+    func testFinishBeforePIDStillHandlesLateOpenCompletion() {
+        let fixture = Fixture()
+        let guardObject = fixture.makeGuard(attempts: 1)
+        defer { guardObject.disarmAfterObservedReveal(); fixture.drain() }
+        guardObject.finish()
+        fixture.drain()
+        let process = Process()
+        fixture.add(process)
+        guardObject.applicationOpened(pid: 1)
+        fixture.drain()
+        XCTAssertEqual(fixture.queue.sync { process.unhideRequests }, 1)
+    }
+
+    func testEarlyFinishKeepsIndependentDeadlineDiscovery() {
+        let fixture = Fixture()
+        let guardObject = fixture.makeGuard(timeout: 0.03, attempts: 1)
+        defer { guardObject.disarmAfterObservedReveal(); fixture.drain() }
+        guardObject.finish()
+        fixture.drain() // No process existed during this exhausted batch.
+        let process = Process()
+        let requested = DispatchSemaphore(value: 0)
+        process.onUnhide = { requested.signal() }
+        fixture.add(process)
+        XCTAssertEqual(requested.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(fixture.queue.sync { process.unhideRequests }, 1)
+    }
+
+    func testPreexistingProcessIsNeverUnhidden() {
+        let existing = Process()
+        let fixture = Fixture(initial: [existing])
+        fixture.byPID[1] = existing
+        let guardObject = fixture.makeGuard(attempts: 1)
+        defer { guardObject.disarmAfterObservedReveal(); fixture.drain() }
+        guardObject.finish()
+        guardObject.applicationOpened(pid: 1)
+        fixture.drain()
+        XCTAssertEqual(fixture.queue.sync { existing.unhideRequests }, 0)
+        let newProcess = Process()
+        fixture.add(newProcess, pid: 2)
+        guardObject.applicationOpened(pid: 2)
+        fixture.drain()
+        XCTAssertEqual(fixture.queue.sync { newProcess.unhideRequests }, 1)
+    }
+
+    func testAmbiguousProcessesWaitForExactCompletion() {
+        let fixture = Fixture()
+        let guardObject = fixture.makeGuard(attempts: 1)
+        defer { guardObject.disarmAfterObservedReveal(); fixture.drain() }
+        let first = Process()
+        let second = Process()
+        fixture.add(first, pid: 1)
+        fixture.add(second, pid: 2)
+        guardObject.finish()
+        fixture.drain()
+        XCTAssertEqual(fixture.queue.sync { first.unhideRequests + second.unhideRequests }, 0)
+        guardObject.applicationOpened(pid: 2)
+        fixture.drain()
+        XCTAssertEqual(fixture.queue.sync { first.unhideRequests }, 0)
+        XCTAssertEqual(fixture.queue.sync { second.unhideRequests }, 1)
+    }
+
+    func testRetryBudgetIsBoundedAndCannotBeRestartedByRepeatedCallbacks() {
+        let fixture = Fixture()
+        let guardObject = fixture.makeGuard(timeout: 0.02, attempts: 3)
+        defer { guardObject.disarmAfterObservedReveal(); fixture.drain() }
+        let process = Process()
+        fixture.add(process)
+        guardObject.finish()
+        fixture.allowRetries()
+        XCTAssertEqual(fixture.queue.sync { process.unhideRequests }, 3)
+        for _ in 0..<10 {
+            guardObject.finish()
+            guardObject.applicationOpened(pid: 1)
+        }
+        fixture.allowRetries()
+        XCTAssertEqual(fixture.queue.sync { process.unhideRequests }, 3)
+    }
+
+    func testVisibleReadbackDisarmsFurtherRequestsEvenWhenUnhideWasRejected() {
+        let fixture = Fixture()
+        let guardObject = fixture.makeGuard()
+        defer { guardObject.disarmAfterObservedReveal(); fixture.drain() }
+        let process = Process()
+        process.acceptsUnhide = false
+        process.onUnhide = { [weak process] in process?.isHidden = false }
+        fixture.add(process)
+        guardObject.finish()
+        fixture.allowRetries()
+        XCTAssertEqual(fixture.queue.sync { process.unhideRequests }, 1)
+        fixture.queue.sync { process.isHidden = true }
+        guardObject.finish()
+        guardObject.applicationOpened(pid: 1)
+        fixture.allowRetries()
+        XCTAssertEqual(fixture.queue.sync { process.unhideRequests }, 1)
+    }
+
+    func testTerminatedProcessIsNotUnhidden() {
+        let fixture = Fixture()
+        let guardObject = fixture.makeGuard()
+        defer { guardObject.disarmAfterObservedReveal(); fixture.drain() }
+        let process = Process()
+        process.isTerminated = true
+        fixture.add(process)
+        guardObject.applicationOpened(pid: 1)
+        guardObject.finish()
+        fixture.allowRetries()
+        XCTAssertEqual(fixture.queue.sync { process.unhideRequests }, 0)
+    }
+
+    func testDisarmDuringInFlightRequestPreventsFurtherRetries() {
+        let fixture = Fixture()
+        let guardObject = fixture.makeGuard()
+        defer { guardObject.disarmAfterObservedReveal(); fixture.drain() }
+        let process = Process()
+        let started = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+        process.onUnhide = {
+            started.signal()
+            _ = release.wait(timeout: .now() + 1)
+        }
+        fixture.add(process)
+        guardObject.finish()
+        XCTAssertEqual(started.wait(timeout: .now() + 1), .success)
+        // Disarm must not wait for the OS request, which cannot be recalled.
+        guardObject.disarmAfterObservedReveal()
+        release.signal()
+        guardObject.finish()
+        guardObject.applicationOpened(pid: 1)
+        fixture.allowRetries()
+        XCTAssertEqual(fixture.queue.sync { process.unhideRequests }, 1)
+    }
+}

--- a/HyprMacTests/LaunchLayoutReservationTests.swift
+++ b/HyprMacTests/LaunchLayoutReservationTests.swift
@@ -1,0 +1,163 @@
+import Cocoa
+import XCTest
+@testable import HyprMac
+
+final class LaunchLayoutReservationTests: XCTestCase {
+    private let layout = LayoutEngine(gapSize: 8, outerPadding: 8, minSlotDimension: 500)
+    private let rect = CGRect(x: 100, y: 50, width: 1920, height: 1080)
+
+    private func plan(_ tree: BSPTree, maxDepth: Int = 3,
+                      incoming: CGSize = .zero,
+                      minimumSize: (HyprWindow?) -> CGSize = { _ in .zero }) -> LaunchLayoutPlan? {
+        layout.planLaunchReservation(in: tree, maxDepth: maxDepth, rect: rect,
+                                     incomingMinimumSize: incoming, minimumSize: minimumSize)
+    }
+
+    func testEmptyTreeReservesPaddedRectWithoutPlaceholder() throws {
+        let tree = BSPTree()
+        let root = tree.root
+        let result = try XCTUnwrap(plan(tree))
+        XCTAssertEqual(result.reservedFrame, rect.insetBy(dx: 8, dy: 8))
+        XCTAssertTrue(result.siblingLayouts.isEmpty)
+        XCTAssertTrue(tree.root === root)
+        XCTAssertTrue(tree.root.isEmpty)
+        XCTAssertTrue(tree.allWindows.isEmpty)
+    }
+
+    func testOneWindowReservesRightHalfAndMovesOnlyExistingTenant() throws {
+        let tree = BSPTree()
+        let window = makeWindow(id: 1)
+        tree.insert(window)
+        let result = try XCTUnwrap(plan(tree))
+        let padded = rect.insetBy(dx: 8, dy: 8)
+        let (left, right) = layout.splitRects(padded, dir: .horizontal)
+        XCTAssertEqual(result.siblingLayouts.count, 1)
+        XCTAssertTrue(result.siblingLayouts[0].0 === window)
+        XCTAssertEqual(result.siblingLayouts[0].1, left)
+        XCTAssertEqual(result.reservedFrame, right)
+        XCTAssertEqual(right.minX - left.maxX, 8)
+        XCTAssertTrue(tree.root.window === window)
+        XCTAssertNil(tree.root.left)
+        XCTAssertNil(tree.root.right)
+    }
+
+    func testProposalMatchesOrdinaryInsertionWithKnownZeroMinima() throws {
+        let tree = BSPTree()
+        for id in 1...3 { tree.insert(makeWindow(id: CGWindowID(id))) }
+        tree.root.splitRatio = 0.7
+        tree.root.userSetRatio = true
+        let result = try XCTUnwrap(plan(tree, maxDepth: 4))
+        let incoming = makeWindow(id: 4)
+        tree.root.clearUserSetRatios()
+        tree.root.resetSplitRatios()
+        XCTAssertTrue(layout.smartInsertFitting(incoming, into: tree, maxDepth: 4,
+                                                rect: rect, minimumSize: { _ in .zero }))
+        let actual = tree.layout(in: rect, gap: 8, padding: 8)
+        XCTAssertEqual(actual.count, result.siblingLayouts.count + 1)
+        XCTAssertEqual(actual.first(where: { $0.0 === incoming })?.1, result.reservedFrame)
+        for (window, frame) in result.siblingLayouts {
+            XCTAssertEqual(actual.first(where: { $0.0 === window })?.1, frame)
+        }
+    }
+
+    func testPlanningRestoresRatiosFlagsOverridesAndTopology() throws {
+        let tree = BSPTree()
+        for id in 1...3 { tree.insert(makeWindow(id: CGWindowID(id))) }
+        let root = tree.root
+        let left = try XCTUnwrap(root.left)
+        let right = try XCTUnwrap(root.right)
+        root.splitRatio = 0.72
+        root.userSetRatio = true
+        root.splitOverride = .horizontal
+        right.splitRatio = 0.3
+        right.userSetRatio = true
+        right.splitOverride = .vertical
+        left.splitOverride = .vertical
+        let before = tree.layout(in: rect, gap: 8, padding: 8).map { $0.1 }
+        _ = try XCTUnwrap(plan(tree, maxDepth: 4))
+        XCTAssertTrue(tree.root === root)
+        XCTAssertTrue(root.left === left)
+        XCTAssertTrue(root.right === right)
+        XCTAssertEqual(root.splitRatio, 0.72)
+        XCTAssertTrue(root.userSetRatio)
+        XCTAssertEqual(root.splitOverride, .horizontal)
+        XCTAssertEqual(right.splitRatio, 0.3)
+        XCTAssertTrue(right.userSetRatio)
+        XCTAssertEqual(right.splitOverride, .vertical)
+        XCTAssertEqual(left.splitOverride, .vertical)
+        XCTAssertEqual(tree.allWindows.map(\.windowID), [1, 2, 3])
+        XCTAssertEqual(tree.layout(in: rect, gap: 8, padding: 8).map { $0.1 }, before)
+    }
+
+    func testLeafOverrideIsNotInheritedByTheProposedSplit() throws {
+        let tree = BSPTree()
+        tree.insert(makeWindow(id: 1))
+        tree.root.splitOverride = .vertical
+        let result = try XCTUnwrap(plan(tree))
+        let (_, right) = layout.splitRects(rect.insetBy(dx: 8, dy: 8), dir: .horizontal)
+        XCTAssertEqual(result.reservedFrame, right)
+        XCTAssertEqual(tree.root.splitOverride, .vertical)
+    }
+
+    func testDepthLimitFailsWithoutChangingTree() {
+        let tree = BSPTree()
+        tree.insert(makeWindow(id: 1))
+        tree.insert(makeWindow(id: 2))
+        tree.root.splitRatio = 0.7
+        tree.root.userSetRatio = true
+        XCTAssertNil(plan(tree, maxDepth: 1))
+        XCTAssertEqual(tree.root.splitRatio, 0.7)
+        XCTAssertTrue(tree.root.userSetRatio)
+        XCTAssertEqual(tree.allWindows.map(\.windowID), [1, 2])
+    }
+
+    func testIncomingMinimumMustFitActualMidpointSlot() {
+        let tree = BSPTree()
+        tree.insert(makeWindow(id: 1))
+        // 1000px could fit with an unequal ratio, not in this 948px slot.
+        XCTAssertNil(plan(tree, incoming: CGSize(width: 1000, height: 200)))
+        XCTAssertEqual(tree.allWindows.map(\.windowID), [1])
+        XCTAssertTrue(tree.root.isLeaf)
+    }
+
+    func testExistingTenantMinimumMustFitActualMidpointSlot() {
+        let tree = BSPTree()
+        tree.insert(makeWindow(id: 1))
+        XCTAssertNil(plan(tree, minimumSize: { _ in CGSize(width: 1000, height: 200) }))
+        XCTAssertTrue(tree.root.isLeaf)
+    }
+
+    func testEverySiblingIsValidatedAfterRatioNormalization() {
+        let tree = BSPTree()
+        tree.insert(makeWindow(id: 1))
+        tree.insert(makeWindow(id: 2))
+        tree.root.splitRatio = 0.7
+        tree.root.userSetRatio = true
+        // The new leaf would be in the right branch, but resetting root's
+        // 70/30 ratio also shrinks the unrelated left sibling below its min.
+        XCTAssertNil(plan(tree, minimumSize: { window in
+            window?.windowID == 1 ? CGSize(width: 1200, height: 200) : .zero
+        }))
+        XCTAssertEqual(tree.root.splitRatio, 0.7)
+        XCTAssertTrue(tree.root.userSetRatio)
+    }
+
+    func testEmptyTreeRejectsOversizedOrInvalidIncomingMinimum() {
+        let tree = BSPTree()
+        XCTAssertNil(plan(tree, incoming: CGSize(width: 2000, height: 100)))
+        XCTAssertNil(plan(tree, incoming: CGSize(width: CGFloat.infinity, height: 100)))
+        XCTAssertNil(plan(tree, incoming: CGSize(width: CGFloat.nan, height: 100)))
+        XCTAssertNil(plan(tree, incoming: CGSize(width: -1, height: 100)))
+        XCTAssertTrue(tree.root.isEmpty)
+    }
+
+    func testPaddingAndGapsCannotProduceNonpositiveSlots() {
+        let tree = BSPTree()
+        tree.insert(makeWindow(id: 1))
+        let tiny = CGRect(x: 0, y: 0, width: 20, height: 20)
+        XCTAssertNil(layout.planLaunchReservation(in: tree, maxDepth: 3, rect: tiny,
+                                                  incomingMinimumSize: .zero,
+                                                  minimumSize: { _ in .zero }))
+        XCTAssertTrue(tree.root.isLeaf)
+    }
+}

--- a/HyprMacTests/ToggleSplitFallthroughRegressionTests.swift
+++ b/HyprMacTests/ToggleSplitFallthroughRegressionTests.swift
@@ -2,6 +2,16 @@ import XCTest
 import Cocoa
 @testable import HyprMac
 
+private final class NoOpApplicationActivator: ApplicationActivating {
+    func activate(bundleID: String,
+                  source: ApplicationActivationSource,
+                  completion: @escaping (ApplicationActivationResult) -> Void)
+        -> ApplicationActivationHandle {
+        completion(.unavailable)
+        return ApplicationActivationHandle()
+    }
+}
+
 // pins the WindowManager.toggleSplit single-mutation behavior. with animation
 // stripped, the dispatcher just calls tilingEngine.toggleSplit directly — but
 // the regression test stays as a guard against future reintroduction of a
@@ -20,7 +30,7 @@ final class ToggleSplitFallthroughRegressionTests: XCTestCase {
     private var accessibility: AccessibilityManager!
     private var cursorManager: CursorManager!
     private var keybindOverlay: KeybindOverlayController!
-    private var appLauncher: AppLauncherManager!
+    private var appLauncher: ApplicationActivating!
     private var workspaceOrchestrator: WorkspaceOrchestrator!
     private var floatingController: FloatingWindowController!
     private var dispatcher: ActionDispatcher!
@@ -51,7 +61,7 @@ final class ToggleSplitFallthroughRegressionTests: XCTestCase {
         accessibility = AccessibilityManager()
         cursorManager = CursorManager()
         keybindOverlay = KeybindOverlayController()
-        appLauncher = AppLauncherManager()
+        appLauncher = NoOpApplicationActivator()
 
         workspaceManager = WorkspaceManager(displayManager: displayManager)
         tilingEngine = TilingEngine(displayManager: displayManager)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ The physical Hypr key is configurable in Settings → General. Options include C
 
 ---
 
+## Spotlight and Shortcuts
+
+On macOS Tahoe 26+, search Spotlight for **Open App with HyprMac** and choose an app. This uses the same activation workflow as HyprMac's app hotkeys, including existing, hidden, and minimized windows. The action is also available in Shortcuts on macOS 15+; HyprMac itself still supports macOS 13+.
+
+For quick access, assign an abbreviation such as `hm` using Spotlight's **Add quick keys** control. Quick Keys and result ranking are managed by macOS, not HyprMac. Ordinary Spotlight app results and Dock launches are not intercepted.
+
+Before a cold launch, HyprMac predicts a tile and reflows only existing windows that need to move, with a short asynchronous frame check before starting the app. The slot is geometric, not a fake window or saved setting. The app then receives a hidden-start request so its real windows can be laid out before reveal when it cooperates; restored window counts or minimum sizes can still require a new layout. Failures or user overrides release the reservation and retile current state. Scratchpad restoration keeps its existing reveal and stacking path.
+
+This is best-effort, with bounded fail-open cleanup—not a guarantee that another app's first frame can never appear. No config migration is needed. See [setup and limitations](docs/keybinds-and-actions.md#opening-apps-with-hotkeys-spotlight-and-shortcuts) and [the reservation lifecycle](docs/architecture.md#application-activation-and-spotlight).
+
+---
+
 ## Menu Bar Access
 
 Focus-follows-mouse and the macOS menu bar don't always play nicely together — mousing up to the menu bar can accidentally shift focus to a window underneath. HyprMac handles this two ways:
@@ -140,7 +152,7 @@ HotkeyManager (CGEventTap)
             ├→ WorkspaceOrchestrator      (workspace switch / move)
             ├→ FloatingWindowController   (toggle / cycle / raise)
             ├→ TilingEngine               (swap / split toggle / retile)
-            └→ AppLauncherManager         (launch / focus)
+            └→ ApplicationActivationCoordinator (open / reveal)
                 ↓
         WindowStateCache mutations
                 ↓
@@ -159,7 +171,7 @@ PollingScheduler (1 Hz timer + coalesced notification triggers)
 
 Window-keyed state lives in `WindowStateCache`; focus state in `FocusStateController`; date-gated suppressions (`activation-switch`, `mouse-focus`, `cross-swap-in-flight`) in `SuppressionRegistry`. BSP trees live in `TilingEngine` (one per `(workspace, screen)` pair) with smart insert backtracking on constrained monitors and two-pass min-size resolution via `FrameReadbackPoller`.
 
-Everything runs on the main thread. UI-touching classes (`FocusBorder`, `DimmingOverlay`, `KeybindOverlayController`, `CursorManager`, `MouseTrackingManager`) assert this in DEBUG via `mainThreadOnly()`.
+Window management and UI mutation run on the main thread. UI-touching classes (`FocusBorder`, `DimmingOverlay`, `KeybindOverlayController`, `CursorManager`, `MouseTrackingManager`) assert this in DEBUG via `mainThreadOnly()`. The event tap has its own thread; Spotlight's installed-app catalog is actor-isolated, and its activation bridge calls the same main-thread coordinator used by app hotkeys.
 
 For deeper reading:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,7 @@ the build / run / style guide; this is the structural narrative.
 ```
 HyprMac/
 ├── App/                      lifecycle, settings shell, menu bar
+├── AppIntents/               Spotlight/Shortcuts entry point, app catalog
 ├── Core/
 │   ├── Discovery/            window discovery service
 │   ├── Input/                drag-swap result application
@@ -34,8 +35,10 @@ HyprMac/
 
 `WindowManager` constructs the dependency graph at app launch and
 holds the only strong reference to most subsystems. The graph stays
-live for the entire app lifetime; nothing in HyprMac is process-wide
-singleton except `UserConfig.shared` and `MenuBarState.shared`.
+live for the app lifetime. `UserConfig.shared`, `MenuBarState.shared`,
+and the installed-app catalog are shared entry points. The App Intent
+bridge holds only a weak reference to the activation service owned by
+`WindowManager`.
 
 | Service | Responsibility |
 |---|---|
@@ -55,7 +58,9 @@ singleton except `UserConfig.shared` and `MenuBarState.shared`.
 | `FocusBrackets` | Corner brackets shown around the focus target while the Hypr key is held. |
 | `DimmingOverlay` | Dim mask over non-focused tiled windows; one panel per display at `.floating - 1`. |
 | `CursorManager` | Cursor warp via `CGWarpMouseCursorPosition` + reassociate dance. |
-| `AppLauncherManager` | Launch-or-focus path for the `launchApp` action. |
+| `ApplicationActivationCoordinator` | Shared open-or-reveal workflow for app hotkeys and Spotlight/Shortcuts; implemented in `AppLauncherManager.swift`. |
+| `ApplicationLaunchVisibilityGuard` | Bounded fail-open cleanup for an app HyprMac requested to launch hidden. |
+| `InstalledApplicationCatalog` | Actor-isolated, cached public-API app discovery for the App Intent parameter. |
 | `KeybindOverlayController` | HUD panel listing every active keybind (`Hypr+K`). |
 
 ## Orchestration layer (Core/Orchestration + Core/State + Core/Discovery)
@@ -115,7 +120,7 @@ HotkeyManager.eventTap (CGEventTap, dedicated thread → dispatched to main)
     ├ WorkspaceOrchestrator      (workspace switch / move)
     ├ FloatingWindowController   (toggle / cycle / raise)
     ├ TilingEngine               (swap / split toggle / retile)
-    └ AppLauncherManager         (launch / focus)
+    └ ApplicationActivationCoordinator (open / reveal)
         ↓
 WindowStateCache mutations
         ↓
@@ -140,6 +145,102 @@ PollingScheduler.timer (10s reconcile net)     ┘        (coalesced)
 Per-app AXObserver notifications are the primary discovery trigger; the
 10s timer only backstops missed events and observer-refusing apps.
 
+## Application activation and Spotlight
+
+The `launchApp(bundleID:)` hotkey and the **Open App with HyprMac** App
+Intent call the same `ApplicationActivating` service. The intent never
+launches a second, independent `NSWorkspace` workflow:
+
+```
+Hotkey → ActionDispatcher ──────────────────────────────┐
+Spotlight / Shortcuts → App Intent → main-actor bridge ─┤
+                                                      ↓
+                         ApplicationActivationCoordinator
+                           → cold launch: reserve / reflow → launch
+                           → AX inventory / preparation / restoration
+                           → exact-window workspace or scratchpad routing
+                           → focus
+```
+
+The coordinator pins a request to one process and one selected window.
+It prefers a non-minimized window, then the last-focused, AX-focused,
+or main window, using the window ID as a stable tie-breaker. Existing
+windows are restored and routed through the normal workspace or
+scratchpad path. A running app receives a reopen request only when AX
+successfully reports no windows; an unavailable AX inventory is not
+treated as an empty one.
+
+For a cold launch, the coordinator first asks the tiling layer for a
+**geometric slot plan** on the target workspace. This plan is transient:
+it creates neither a fake window nor a placeholder in the live BSP
+tree, and nothing is persisted. Existing tiled siblings are reflowed
+before Launch Services is called; only siblings whose target frame
+changes receive AX writes. Frame readback is checked asynchronously
+at 40 ms intervals with a 350 ms verification budget. A sibling that
+does not accept its frame causes the speculative gap to be released
+and the launch to continue through the safe fallback. These are
+readback scheduling bounds, not guarantees about AX call latency.
+
+Normal discovery polling is held off for a bounded reservation period
+so it does not immediately fill the deliberately empty gap. AX events
+still reach the coordinator. After verification, Launch Services
+receives `NSWorkspace.OpenConfiguration` with `activates = false` and
+`hides = true`. If the app cooperates, the coordinator waits for a
+bounded window-creation burst and prepares its addressable windows
+before reveal. Actual windows enter ordinary discovery and BSP
+insertion; they do not replace fake nodes. The initial slot is only a
+prediction: restored window count and real minimum sizes can require
+another layout before reveal. Scratchpad windows use their existing
+reveal and stacking sequence rather than a second speculative layout.
+
+This is best-effort preparation, **not a pre-map interception
+guarantee**: public macOS APIs do not let HyprMac suspend another app
+before its first window appears. Apps can ignore the hidden launch
+request or reject geometry changes; already-visible apps are never
+hidden to compensate.
+
+Requests have a deadline, cancellation, and stale-callback checks.
+Repeated requests for the same app share the pending operation; a new
+app request or an explicit user override cancels it. The visibility
+guard outlives request cancellation when necessary and provides bounded
+fail-open cleanup, including late launch completion. The safety rule
+is to undo HyprMac's hidden-launch request without stealing focus back
+after the user moves on, even if layout preparation fails.
+The guard has a separate serial queue and only uses the documented
+thread-safe `NSRunningApplication` unhide API there; AX work and view
+mutation stay on the main thread. This gives cleanup an independent
+chance to run while main-thread AX calls are busy, not a no-jank or
+visibility guarantee. Once a reveal has been observed, the guard is
+irreversibly disarmed so a later intentional Cmd-H is not undone.
+On failure, timeout, or user override, the speculative reservation is
+discarded and current live geometry is retiled. Rollback never restores
+an old tree or saved frames over a newer user action or display change.
+
+The App Intent and App Shortcut provider live in the main app target;
+there is no extension or private launch interception API. They are
+availability-gated to macOS 15, while direct Spotlight actions require
+macOS Tahoe 26. The rest of HyprMac still targets macOS 13. The intent
+keeps HyprMac itself in the background and awaits the shared service;
+only activation or the explicit no-manageable-window fallback counts
+as success. If Spotlight starts HyprMac, the bridge waits asynchronously
+for service installation and the initial window snapshot, up to two
+seconds. It never activates an app through a partially initialized
+manager. Cancellation and errors propagate to the caller.
+
+`InstalledApplicationEntity` uses bundle IDs as stable identifiers.
+Its query scans standard application folders, skips background-only and
+agent apps, deduplicates IDs deterministically, and caches the results
+for five minutes. Suggestions are alphabetic rather than dependent on
+which apps happen to be running. Saved IDs outside those folders can
+also resolve through public `NSWorkspace` lookup. This is not an
+exhaustive index of every app in arbitrary filesystem locations.
+
+Spotlight owns ranking and Quick Keys; HyprMac does not overwrite its
+preferences or promise first-place results. The existing `launchApp`
+JSON format is unchanged, and this integration needs no config
+migration. See [keybinds and actions](keybinds-and-actions.md#opening-apps-with-hotkeys-spotlight-and-shortcuts)
+for setup and platform limits.
+
 ## Ownership rules
 
 - **`WindowStateCache`** is the only owner of window-keyed
@@ -159,7 +260,7 @@ Per-app AXObserver notifications are the primary discovery trigger; the
 
 ## Threading
 
-Every public method runs on the main thread, with one exception: the
+Window management and UI mutation run on the main thread. The
 CGEventTap lives on its own dedicated thread (`HyprMac.EventTap`). It
 is an *active* tap — macOS holds all system keyboard input until the
 hosting run loop services the callback — so it must never share a run
@@ -171,7 +272,12 @@ still fire on the main run loop. UI-touching classes (`FocusBorder`,
 `MouseTrackingManager`) call `mainThreadOnly()` on entry so an
 off-main caller crashes loudly in DEBUG.
 
-There is no `async/await` in HyprMac today.
+App Intent queries use `async/await` and an actor-isolated installed-app
+catalog, so filesystem scans do not run on the main actor. The
+`@MainActor` activation bridge adapts the intent's async completion and
+cancellation to the main-thread coordinator's callback interface.
+The visibility guard's separate serial queue performs bounded public
+unhide requests only; it does not move AX calls off the main thread.
 
 ## Logging
 

--- a/docs/keybinds-and-actions.md
+++ b/docs/keybinds-and-actions.md
@@ -36,6 +36,49 @@ adjacent monitor's visible workspace — the case was repurposed from
 the old workspace-to-monitor move, which static anchoring made a
 permanent no-op; its wire key is unchanged (see below).
 
+## Opening apps with hotkeys, Spotlight, and Shortcuts
+
+App hotkeys (`launchApp(bundleID:)`) and **Open App with HyprMac** use
+the same activation service. It opens a stopped app, focuses an existing
+window, restores a hidden or minimized window, and follows HyprMac's
+workspace/scratchpad routing. A running app is not blindly relaunched.
+App hotkeys are configured in Settings → Keybinds as before.
+
+On **macOS Tahoe 26 or later**, press Command-Space and search for
+**Open App with HyprMac**. Command-3 narrows the results to actions.
+Choose the action, select the application, and press Return. The app
+parameter searches installed app names and bundle IDs; there is no
+separate HyprMac action to maintain for every installed app.
+
+To make the action easier to reach, use Spotlight's **Add quick keys**
+control next to the action and assign an abbreviation such as `hm`.
+Typing that abbreviation brings up the action and its app parameter.
+Quick Keys belong to macOS: HyprMac cannot assign them, sync them in
+`config.json`, or force this action above normal app results. Opening a
+normal Spotlight app result or clicking a Dock icon does not run the
+HyprMac action. Apple's [Spotlight actions guide](https://support.apple.com/en-mide/guide/mac-help/mchl4953dfeb/mac)
+describes assigning and editing Quick Keys.
+
+On **macOS 15 or later**, the same action is available in Shortcuts.
+Add it to a shortcut and select an app there if a saved, app-specific
+entry point is preferable. macOS 13 and 14 retain the existing app
+hotkeys; the minimum OS version for HyprMac itself is unchanged.
+
+Cold launches first attempt a geometric slot reservation: affected
+existing tiles move and their frames are checked before the app starts.
+The app then receives a hidden-start request so real windows can be
+positioned before reveal when it cooperates. Unknown restored window
+counts or minimum sizes can require replanning. This is best-effort,
+not a promise of an invisible first frame. Failure or user override
+releases the reservation by retiling current state, and bounded
+fail-open cleanup releases HyprMac's hidden-launch request if
+preparation cannot finish. Scratchpad restoration keeps its existing
+reveal and stacking behavior. See [the activation architecture](architecture.md#application-activation-and-spotlight)
+for lifecycle and safety details.
+
+No new persisted settings are needed. Existing app hotkeys keep their
+`launchApp` wire format, so this change requires no config migration.
+
 ## JSON wire format
 
 The `Codable` implementation in `Models/Action.swift` preserves the


### PR DESCRIPTION
## Summary

Add one request-scoped application activation workflow shared by existing app hotkeys and a native **Open App with HyprMac** App Intent/App Shortcut. The central change is ordering: when a cold launch has a safe predicted tile, move the affected existing windows and check their frames **before** asking Launch Services to open the application.

This is a draft for architecture review and real-machine validation, not a claim that public macOS APIs provide an atomic or universally flicker-free reveal.

## Behavior

- Preview one incoming tile using the current workspace's BSP geometry and known minimum sizes. No fake window, persistent placeholder, or saved-tree rollback is introduced. Only siblings whose frames change receive pre-launch geometry writes, with bounded readback before launch.
- Open a cold application with public `NSWorkspace.OpenConfiguration` (`activates = false`, `hides = true`). When the application cooperates, collect its window burst, run its actual windows through existing discovery/workspace/tiling ownership, check geometry, then reveal and route one exact window.
- Existing visible applications are never hidden. Hidden applications and the selected minimized window use the same prepare/restore/route flow; unrelated minimized documents stay minimized. Scratchpad targets retain the existing reveal/stacking path.
- Coalesce repeated requests for the same app. New requests, typing/clicking, foreign app activation, stop/sleep, and relevant layout/display changes cancel stale work. Original input timestamps keep Spotlight's triggering Return/click from cancelling its own action. Delayed focus reassertion is request-guarded.
- Distinguish unavailable AX data from a genuinely empty window list; never send a reopen merely because AX failed. Modal/unaddressable windows use the application's own focus behavior. Deadlines and late-callback cleanup fail open without activating an obsolete request.
- A bounded visibility backstop uses thread-safe, public `NSRunningApplication.unhide()` requests on a separate queue. It is permanently disarmed after an observed reveal and never activates an app. It is best-effort cleanup, not a guarantee against an OS stall or process death.

## Spotlight, compatibility, and migration

- App Intents are gated to macOS 15; direct Spotlight actions require macOS Tahoe 26. The app deployment target remains macOS 13, and the new sources also type-check against the macOS 15.4 SDK.
- App entities use stable bundle IDs, a cached standard-folder catalog, deterministic suggestions, and public Launch Services resolution for saved IDs. The intent waits for HyprMac's initial window snapshot before using the service.
- Settings explains the shared action and how to assign a Spotlight Quick Key. **macOS owns Quick Keys and ranking**; this does not modify Spotlight preferences or promise the top search result. Existing HyprMac app hotkeys remain editable in Settings.
- No new permissions, entitlements, shell launch commands, injection, or private launch APIs. Existing HyprMac AX/window-ID/focus infrastructure is reused; this does not claim that the whole existing app is private-API-free.
- Existing `launchApp` keybind JSON is unchanged; no config migration is required. The separate pending corner-radius follow-up is deliberately not included. Base: current upstream `main` at `5b69318`.

## Resource bounds

No new permanent polling timer, screen capture, animation renderer, or helper process. Reservation readback is bounded, request timers end on completion/cancellation, discovery retries are throttled, and exact-window routing resolves only the selected application's AX windows instead of rescanning every app on each retry. The installed-app catalog is cached for five minutes. Actual CPU/RAM/GPU and visual latency have not yet been profiled on a running build.

## Test notes

- Full application Swift type-check passed with macOS 15.4 and 26.5 SDKs, Swift 5 mode, and an arm64 macOS 13 deployment target. A temporary minimal Sparkle interface stub was used solely for this check; this is **not** a linked application build or Sparkle integration test. Only existing `AXNotificationService` cast warnings were emitted.
- 29 deterministic coordinator tests passed with zero assertion failures, covering pre-launch ordering, cancellation/coalescing, process identity, reentrant completion, bounded discovery retries, grace periods, modal handling, stale callbacks, and release of subscriber captures when the coordinator is destroyed. The production coordinator/visibility-guard sources and the committed XCTest test methods were compiled unchanged; only the OS boundary and XCTest assertion runtime were replaced in a temporary standalone harness.
- 81 geometry test methods passed with zero assertion failures: 11 new reservation tests plus 70 existing BSP/layout tests, using the actual BSP, layout, window-model, and tiling-config sources with a temporary assertion runtime. Tests check that predictions respect known minima/depth/padding and leave the real tree unchanged.
- 10 visibility-guard test methods passed with zero assertion failures using the real queue/guard and fake process objects, including a blocked main queue, late callbacks, retry bounds, permanent disarm, and an in-flight unhide/disarm race. No real applications were launched or manipulated. All three new XCTest files are registered in the checked-in Xcode project.
- App Intent bridge/catalog smoke checks passed, including startup readiness, cancellation, and timeout. App Intent sources also passed an x86_64 availability type-check.
- `git diff --check` and project/plist validation passed.
- Full Xcode/XCTest, App Intent metadata extraction/signing, and SwiftLint could not be run here: this machine has Command Line Tools but no full Xcode or SwiftLint. Standalone assertion-harness checks are not represented as an Xcode XCTest run.

## Required before marking ready

- [ ] Build and run the full XCTest suite in Xcode; validate App Intent metadata extraction on the supported build toolchain.
- [ ] On macOS 26, discover the action in Spotlight, select an app outside the initial suggestions, assign a Quick Key, and verify that HyprMac itself does not steal foreground focus.
- [ ] Verify cold native and Electron launches with one/multiple restored windows: existing siblings make room before the launch request; real minimum sizes and extra windows are reconciled before reveal when supported.
- [ ] Exercise already-visible, Cmd-H-hidden, minimized, no-window, modal, floating/excluded, scratchpad, disabled-monitor, and hidden-workspace cases. Confirm that unrelated minimized windows remain untouched.
- [ ] Exercise slow/unresponsive applications, denied AX permission, immediate app exit, repeated/competing triggers, cancellation while reserving, and a late launch completion. No stale refocus or permanently stranded hidden window.
- [ ] Disconnect/reconfigure a display, switch workspace, type/click elsewhere, stop HyprMac, and sleep/wake during activation. Confirm that current user intent wins and no speculative gap remains.
- [ ] Profile idle usage and repeated launches with many existing windows; record visual behavior and resource use. Apps that ignore hidden launch, reject geometry, open later windows, or use native Spaces may still fall back to ordinary visible behavior.

### Public platform references

- [Spotlight App Intents integration](https://developer.apple.com/videos/play/wwdc2025/260/)
- [Dynamic App Shortcut entities](https://developer.apple.com/videos/play/wwdc2023/10102/)
- [Apple's Spotlight Quick Key instructions](https://support.apple.com/guide/mac-help/mchl4953dfeb/mac)
